### PR TITLE
Fixed #11: failing tests when stddev was === 0

### DIFF
--- a/test/run.test.js
+++ b/test/run.test.js
@@ -31,7 +31,7 @@ test('run', (t) => {
 
     t.ok(result.throughput, 'throughput exists')
     t.ok(result.throughput.average, 'throughput.average exists')
-    t.ok(result.throughput.stddev, 'throughput.stddev exists')
+    t.type(result.throughput.stddev, 'number', 'throughput.stddev exists')
     t.ok(result.throughput.min, 'throughput.min exists')
     t.ok(result.throughput.max, 'throughput.max exists')
     t.ok(result.throughput.total >= result.throughput.average * 2 / 100 * 95, 'throughput.total exists')
@@ -71,7 +71,7 @@ test('tracker.stop()', (t) => {
 
     t.ok(result.throughput, 'throughput exists')
     t.ok(result.throughput.average, 'throughput.average exists')
-    t.ok(result.throughput.stddev, 'throughput.stddev exists')
+    t.type(result.throughput.stddev, 'number', 'throughput.stddev exists')
     t.ok(result.throughput.min, 'throughput.min exists')
     t.ok(result.throughput.max, 'throughput.max exists')
     t.ok(result.throughput.total >= result.throughput.average * 2 / 100 * 95, 'throughput.total exists')


### PR DESCRIPTION
Fixing this required I assert that the type of stddev is a number, instead of a truthy value.