### PR TITLE
Fixes #10: Render progress bar programmatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,36 @@ Start autocannon against the given target, options:
 * `duration`: the number of seconds to run the autocannon
 * `body`: a `Buffer` containing the body of the request
 * `method`: the http method to use, `GET` is the default
-* `renderProgressBar`: A truthy value to enable the rendering of the progress bar. false by default
-* `progressBarString`: A `string` defining the format of the progress display output. Must be valid input for the [progress bar module](http://npm.im/progress).
+
+**Returns** an instance/event emitter for tracking progress, etc.
+
+### autocannon.track(instance[, outputStream])
+
+* `instance`: the instance of autocannon
+* `opts`: OPTIONAL. configuration options for tracking. this can have the
+following attibutes
+    * `outputStream`: the stream to output to. Defaults to process.stderr
+    * `renderProgressBar`: A truthy value to enable the rendering of the progress bar. true by default
+    * `renderResultTable`: A truthy value to enable the rendering of the results table. true by default
+    * `progressBarString`: A `string` defining the format of the progress display output. Must be valid input for the [progress bar module](http://npm.im/progress). Defaults to the progress bar output seen in the demo above
+
+Example:
+
+```js
+'use strict'
+
+const autocannon = require('autocannon')
+
+const instance = autocannon({
+  url: 'http://localhost:3000',
+  connections: 10,
+  pipelining: 1, // default
+  duration: 10
+}, console.log)
+
+// just render results
+autocannon.track(instance, {renderProgressBar: false})
+```
 
 <a name="acknowledgements"></a>
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Start autocannon against the given target, options:
 * `duration`: the number of seconds to run the autocannon
 * `body`: a `Buffer` containing the body of the request
 * `method`: the http method to use, `GET` is the default
+* `renderProgressBar`: A truthy value to enable the rendering of the progress bar. false by default
+* `progressBarString`: A `string` defining the format of the progress display output. Must be valid input for the [progress bar module](http://npm.im/progress).
 
 <a name="acknowledgements"></a>
 ## Acknowledgements

--- a/autocannon.js
+++ b/autocannon.js
@@ -6,15 +6,11 @@ const minimist = require('minimist')
 const fs = require('fs')
 const path = require('path')
 const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
-const ProgressBar = require('progress')
-const table = require('table')
-const prettyBytes = require('pretty-bytes')
-const format = require('./lib/format')
-const chalk = require('chalk')
-const percentiles = require('./lib/percentiles')
 const run = require('./lib/run')
+const track = require('./lib/progressTracker')
 
 module.exports = run
+module.exports.track = track
 
 function start () {
   const argv = minimist(process.argv.slice(2), {
@@ -68,108 +64,14 @@ function start () {
       throw err
     }
 
-    if (!argv.json) {
-      const out = table.default([
-        asColor('cyan', ['Stat', 'Avg', 'Stdev', 'Max']),
-        asRow(chalk.bold('Latency (ms)'), result.latency),
-        asRow(chalk.bold('Req/Sec'), result.requests),
-        asRow(chalk.bold('Bytes/Sec'), asBytes(result.throughput))
-      ], {
-        border: table.getBorderCharacters('void'),
-        columnDefault: {
-          paddingLeft: 0,
-          paddingRight: 1
-        },
-        drawHorizontalLine: () => false
-      })
-
-      console.log(out)
-
-      if (argv.latency) {
-        const latency = table.default([
-          asColor('cyan', ['Percentile', 'Latency (ms)'])
-        ].concat(percentiles.map((perc) => {
-          const key = ('p' + perc).replace('.', '')
-          return [
-            chalk.bold('' + perc),
-            result.latency[key]
-          ]
-        })), {
-          border: table.getBorderCharacters('void'),
-          columnDefault: {
-            paddingLeft: 0,
-            paddingRight: 6
-          },
-          drawHorizontalLine: () => false
-        })
-
-        console.log(latency)
-      }
-
-      if (result.non2xx) {
-        console.log(`${result['2xx']} 2xx responses, ${result.non2xx} non 2xx responses`)
-      }
-      console.log(`${format(result.requests.total)} requests in ${result.duration}s, ${prettyBytes(result.throughput.total)} read`)
-      if (result.errors) {
-        console.log(`${format(result.errors)} errors`)
-      }
-    } else {
+    if (argv.json) {
       console.log(JSON.stringify(result, null, 2))
     }
   })
 
   if (!argv.json) {
-    const bar = new ProgressBar(`${chalk.green('running')} [:bar] :percent`, {
-      width: 20,
-      incomplete: ' ',
-      total: argv.duration,
-      clear: true
-    })
-
-    console.log(`Running ${argv.duration}s test @ ${argv.url}`)
-    let msg = `${argv.connections} connections`
-    if (argv.pipelining > 1) {
-      msg += ` with ${argv.pipelining} pipelining factor`
-    }
-    console.log(msg)
-    console.log()
-
-    bar.tick(0)
-
-    tracker.on('tick', () => {
-      bar.tick()
-    })
-
-    process.once('SIGINT', () => {
-      bar.tick(argv.duration - 1)
-    })
+    track(tracker)
   }
-
-  process.once('SIGINT', () => {
-    tracker.stop()
-  })
-}
-
-function asRow (name, stat) {
-  return [
-    name,
-    stat.average,
-    stat.stddev,
-    stat.max
-  ]
-}
-
-function asColor (color, row) {
-  return row.map((entry) => chalk[color](entry))
-}
-
-function asBytes (stat) {
-  const result = Object.create(stat)
-  result.average = prettyBytes(stat.average)
-  result.stddev = prettyBytes(stat.stddev)
-  result.max = prettyBytes(stat.max)
-  result.min = prettyBytes(stat.min)
-  return result
 }
 
 if (require.main === module) {

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -7,43 +7,52 @@ const prettyBytes = require('pretty-bytes')
 const format = require('./format')
 const percentiles = require('./percentiles')
 
-function track (instance, outputStream) {
+function track (instance, opts) {
   if (!instance) {
     throw new Error('instance required for tracking')
   }
 
-  const opts = instance.opts
-
+  opts = opts || {}
   // use stderr as its progressBar's default
-  outputStream = outputStream || process.stderr
+  opts.outputStream = opts.outputStream || process.stderr
+  opts.renderProgressBar = opts.renderProgressBar || true
+  opts.renderResultsTable = opts.renderResultsTable || true
+  opts.progressBarString = opts.progressBarString || `${chalk.green('running')} [:bar] :percent`
 
-  const progressBar = new ProgressBar(`${chalk.green('running')} [:bar] :percent`, {
-    width: 20,
-    incomplete: ' ',
-    total: opts.duration,
-    clear: true,
-    stream: outputStream
-  })
+  const iOpts = instance.opts
+  if (opts.renderProgressBar) {
+    const progressBar = new ProgressBar(opts.progressBarString, {
+      width: 20,
+      incomplete: ' ',
+      total: iOpts.duration,
+      clear: true,
+      stream: opts.outputStream
+    })
 
-  console.log(`Running ${opts.duration}s test @ ${opts.url}`)
-  let msg = `${opts.connections} connections`
-  if (opts.pipelining > 1) {
-    msg += ` with ${opts.pipelining} pipelining factor`
+    console.log(`Running ${iOpts.duration}s test @ ${iOpts.url}`)
+    let msg = `${iOpts.connections} connections`
+    if (iOpts.pipelining > 1) {
+      msg += ` with ${iOpts.pipelining} pipelining factor`
+    }
+    console.log(msg)
+    console.log()
+
+    progressBar.tick(0)
+
+    instance.on('tick', () => {
+      progressBar.tick()
+    })
+
+    process.once('SIGINT', () => {
+      progressBar.tick(opts.duration - 1)
+    })
   }
-  console.log(msg)
-  console.log()
-
-  progressBar.tick(0)
-
-  instance.on('tick', () => {
-    progressBar.tick()
-  })
-
-  process.once('SIGINT', () => {
-    progressBar.tick(opts.duration - 1)
-  })
 
   instance.on('done', (result) => {
+    // the code below this `if` just renders the results table...
+    // if the user doesn't want to render the table, we can just return early
+    if (!opts.renderResultsTable) return
+
     const out = table.default([
       asColor('cyan', ['Stat', 'Avg', 'Stdev', 'Max']),
       asRow(chalk.bold('Latency (ms)'), result.latency),

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const ProgressBar = require('progress')
+const table = require('table')
+const chalk = require('chalk')
+const prettyBytes = require('pretty-bytes')
+const format = require('./format')
+const percentiles = require('./percentiles')
+
+function track (instance, outputStream) {
+  if (!instance) {
+    throw new Error('instance required for tracking')
+  }
+
+  const opts = instance.opts
+
+  // use stderr as its progressBar's default
+  outputStream = outputStream || process.stderr
+
+  const progressBar = new ProgressBar(`${chalk.green('running')} [:bar] :percent`, {
+    width: 20,
+    incomplete: ' ',
+    total: opts.duration,
+    clear: true,
+    stream: outputStream
+  })
+
+  console.log(`Running ${opts.duration}s test @ ${opts.url}`)
+  let msg = `${opts.connections} connections`
+  if (opts.pipelining > 1) {
+    msg += ` with ${opts.pipelining} pipelining factor`
+  }
+  console.log(msg)
+  console.log()
+
+  progressBar.tick(0)
+
+  instance.on('tick', () => {
+    progressBar.tick()
+  })
+
+  process.once('SIGINT', () => {
+    progressBar.tick(opts.duration - 1)
+  })
+
+  instance.on('done', (result) => {
+    const out = table.default([
+      asColor('cyan', ['Stat', 'Avg', 'Stdev', 'Max']),
+      asRow(chalk.bold('Latency (ms)'), result.latency),
+      asRow(chalk.bold('Req/Sec'), result.requests),
+      asRow(chalk.bold('Bytes/Sec'), asBytes(result.throughput))
+    ], {
+      border: table.getBorderCharacters('void'),
+      columnDefault: {
+        paddingLeft: 0,
+        paddingRight: 1
+      },
+      drawHorizontalLine: () => false
+    })
+
+    console.log(out)
+
+    if (opts.latency) {
+      const latency = table.default([
+        asColor('cyan', ['Percentile', 'Latency (ms)'])
+      ].concat(percentiles.map((perc) => {
+        const key = ('p' + perc).replace('.', '')
+        return [
+          chalk.bold('' + perc),
+          result.latency[key]
+        ]
+      })), {
+        border: table.getBorderCharacters('void'),
+        columnDefault: {
+          paddingLeft: 0,
+          paddingRight: 6
+        },
+        drawHorizontalLine: () => false
+      })
+
+      console.log(latency)
+    }
+
+    if (result.non2xx) {
+      console.log(`${result['2xx']} 2xx responses, ${result.non2xx} non 2xx responses`)
+    }
+    console.log(`${format(result.requests.total)} requests in ${result.duration}s, ${prettyBytes(result.throughput.total)} read`)
+    if (result.errors) {
+      console.log(`${format(result.errors)} errors`)
+    }
+  })
+}
+
+function asRow (name, stat) {
+  return [
+    name,
+    stat.average,
+    stat.stddev,
+    stat.max
+  ]
+}
+
+function asColor (color, row) {
+  return row.map((entry) => chalk[color](entry))
+}
+
+function asBytes (stat) {
+  const result = Object.create(stat)
+  result.average = prettyBytes(stat.average)
+  result.stddev = prettyBytes(stat.stddev)
+  result.max = prettyBytes(stat.max)
+  result.min = prettyBytes(stat.min)
+  return result
+}
+
+module.exports = track

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,6 +3,7 @@
 const EE = require('events').EventEmitter
 const URL = require('url')
 const Histogram = require('native-hdr-histogram')
+const ProgressBar = require('progress')
 const Client = require('./myhttp')
 const percentiles = require('./percentiles')
 
@@ -24,6 +25,7 @@ function run (opts, cb) {
   const url = URL.parse(opts.url)
 
   opts.pipelining = opts.pipelining || 1
+  opts.progressBarString = opts.progressBarString || 'Autocannon Progress [:bar] :percent'
 
   let counter = 0
   let bytes = 0
@@ -32,10 +34,20 @@ function run (opts, cb) {
   let totalRequests = 0
   let stop = false
   let startTime = Date.now()
+  let progressBar
 
   if (!opts.connections) {
     cb(new Error('connections > 0'))
     return
+  }
+
+  if (opts.renderProgressBar) {
+    progressBar = new ProgressBar(opts.progressBarString, {
+      width: 20,
+      incomplete: ' ',
+      total: opts.duration,
+      clear: true
+    })
   }
 
   // copy over fields so that the client
@@ -81,6 +93,7 @@ function run (opts, cb) {
     counter = 0
     bytes = 0
     tracker.emit('tick')
+    if (progressBar) progressBar.tick()
 
     if (stop) {
       clearInterval(interval)

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,6 @@
 const EE = require('events').EventEmitter
 const URL = require('url')
 const Histogram = require('native-hdr-histogram')
-const ProgressBar = require('progress')
 const Client = require('./myhttp')
 const percentiles = require('./percentiles')
 
@@ -11,6 +10,8 @@ function run (opts, cb) {
   cb = cb || noop
 
   const tracker = new EE()
+  tracker.opts = opts
+
   const latencies = new Histogram(1, 10000, 5)
   const requests = new Histogram(1, 1000000, 3)
   const throughput = new Histogram(1, 1000000000, 1)
@@ -25,7 +26,6 @@ function run (opts, cb) {
   const url = URL.parse(opts.url)
 
   opts.pipelining = opts.pipelining || 1
-  opts.progressBarString = opts.progressBarString || 'Autocannon Progress [:bar] :percent'
 
   let counter = 0
   let bytes = 0
@@ -34,20 +34,10 @@ function run (opts, cb) {
   let totalRequests = 0
   let stop = false
   let startTime = Date.now()
-  let progressBar
 
   if (!opts.connections) {
     cb(new Error('connections > 0'))
     return
-  }
-
-  if (opts.renderProgressBar) {
-    progressBar = new ProgressBar(opts.progressBarString, {
-      width: 20,
-      incomplete: ' ',
-      total: opts.duration,
-      clear: true
-    })
   }
 
   // copy over fields so that the client
@@ -93,7 +83,6 @@ function run (opts, cb) {
     counter = 0
     bytes = 0
     tracker.emit('tick')
-    if (progressBar) progressBar.tick()
 
     if (stop) {
       clearInterval(interval)

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -83,6 +83,8 @@ test('tracker.stop()', (t) => {
     t.end()
   })
 
+  t.ok(tracker.opts, 'opts exist on tracker')
+
   setTimeout(() => {
     tracker.stop()
   }, 1000)


### PR DESCRIPTION
Users can pass `renderProgressBar: true` to render the
progress bar from an external tool. Additionally, they
can provide `progressBarString: SOME_STRING` to modify
the output format of the progress bar. This string must
meet the format specified in npm.im/progress

This will require a review.

Additionally... how should I test this?