### PR TITLE
fixes #9: Can now change headers and body on client response

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,57 @@ Example:
 const autocannon = require('autocannon')
 
 const instance = autocannon({
-  url: 'http://localhost:3000',
-  connections: 10,
-  pipelining: 1, // default
-  duration: 10
+  url: 'http://localhost:3000'
 }, console.log)
 
 // just render results
 autocannon.track(instance, {renderProgressBar: false})
+```
+
+### autocannon events
+Because an autocannon instance is an `EventEmitter`, it emits several events. these are below:
+* `tick`: emitted every second this autocannon is running a benchmark. Useful for displaying stats, etc. Used by the `track` function.
+* `done`: Emitted when the autocannon finishes a benchmark. passes the `results` as an argument to the callback.
+* `response`: Emitted when the autocannons http-client gets a http response from the server. This passes the following arguments to the callback:
+    * `client`: The `http-client` itself. Can be used to modify the headers and body the client will send to the server. api below
+    * `statusCode`: The http status code of the response
+    * `resBytes`: the response bytes in `Buffer` format
+    * `responseTime`: The time taken to get a response for the initiating the request
+
+### `Client` api
+* `client.setHeaders(headers)`: used to modify the headers of future requests this client makes. `headers` should be an object
+* `client.setBody(body)`: used to modify the body of futures requests this client makes. `body` should be a string or buffer
+* `client.setHeadersAndBody(headers, body)`: used to modify the both the header and body of futures requests this client makes.`headers` should be an object and `body` should be a string or buffer. `Note: call this when modifying both headers and body for faster response encoding`
+
+Example using these events and the client functions:
+```js
+'use strict'
+
+const autocannon = require('autocannon')
+
+const instance = autocannon({
+  url: 'http://localhost:3000'
+}, (err, result) => handleResults(result))
+// results passed to the callback are the same as those emitted from the done events
+instance.on('done', handleResults)
+
+instance.on('tick', () => console.log('ticking'))
+
+instance.on('response', handleResonse)
+
+function handleResponse (client, statusCode, resBytes, responseTime) {
+  console.log(`Got response with code ${statusCode} in ${responseTime} milliseconds`)
+  console.log(`response: ${resBytes.toString()}`)
+
+  //update the body or headers
+  client.setHeaders({new: 'header'})
+  client.setBody('new body')
+  client.setHeadersAndBody({new: 'header'}, 'new body')
+}
+
+function handleResults(result) {
+  // ...
+}
 ```
 
 <a name="acknowledgements"></a>

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -105,6 +105,7 @@ Client.prototype.setBody = function (newBody) {
 }
 
 Client.prototype.setHeadersAndBody = function (newHeaders, newBody) {
+  this.opts.headers = newHeaders || {}
   this.opts.body = newBody
 
   this._rebuild()

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -29,7 +29,6 @@ function Client (opts) {
   this.bytes = 0
   this.headers = {}
   this.startTime = [0, 0]
-  this.body = this.opts.body
 
   this.parser[HTTPParser.kOnHeadersComplete] = (opts) => {
     this.headers = opts
@@ -52,7 +51,7 @@ function Client (opts) {
     opts.host = opts.hostname + ':' + opts.port
   }
 
-  this._req = `${opts.method} ${opts.path} HTTP/1.1\r\nHost: ${opts.host}\r\nConnection: keep-alive\r\n`
+  this.baseReq = `${opts.method} ${opts.path} HTTP/1.1\r\nHost: ${opts.host}\r\nConnection: keep-alive\r\n`
 
   this.setHeaders(opts.headers)
 
@@ -96,42 +95,38 @@ Client.prototype.destroy = function () {
 
 Client.prototype.setHeaders = function (newHeaders) {
   this.opts.headers = newHeaders || {}
-  this.rebuildRequest()
+  this._rebuild()
 }
 
 Client.prototype.setBody = function (newBody) {
   this.opts.body = newBody
-  this.body = newBody
 
-  this.rebuildRequest()
+  this._rebuild()
 }
 
-Client.prototype.rebuildRequest = function () {
-  // this.body should take precedence, as the user can reassign directly to it
-  this.opts.body = this.body || this.opts.body
-
-  let bodyReq
+Client.prototype._rebuild = function () {
+  let body
 
   if (typeof this.opts.body === 'string') {
-    bodyReq = new Buffer(this.opts.body)
+    body = new Buffer(this.opts.body)
   } else if (Buffer.isBuffer(this.opts.body)) {
-    bodyReq = this.opts.body
+    body = this.opts.body
   } else if (this.opts.body) {
     throw new Error('body must be either a string or a buffer')
   }
 
-  if (bodyReq) {
-    this.opts.headers['Content-Length'] = '' + bodyReq.length
+  if (body) {
+    this.opts.headers['Content-Length'] = '' + body.length
   }
 
   this._req = Object.keys(this.opts.headers)
     .map((key) => `${key}: ${this.opts.headers[key]}\r\n`)
-    .reduce((acc, str) => acc + str, this._req)
+    .reduce((acc, str) => acc + str, this.baseReq)
 
   this._req = new Buffer(this._req + '\r\n', 'utf8')
 
-  if (bodyReq) {
-    this._req = Buffer.concat([this._req, bodyReq, new Buffer('\r\n')])
+  if (body) {
+    this._req = Buffer.concat([this._req, body, new Buffer('\r\n')])
   }
 }
 

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -29,6 +29,7 @@ function Client (opts) {
   this.bytes = 0
   this.headers = {}
   this.startTime = [0, 0]
+  this.body = this.opts.body
 
   this.parser[HTTPParser.kOnHeadersComplete] = (opts) => {
     this.headers = opts
@@ -99,23 +100,28 @@ Client.prototype.setHeaders = function (newHeaders) {
 }
 
 Client.prototype.setBody = function (newBody) {
-  this.opts.body = newBody || {}
+  this.opts.body = newBody
+  this.body = newBody
+
   this.rebuildRequest()
 }
 
 Client.prototype.rebuildRequest = function () {
-  let body
+  // this.body should take precedence, as the user can reassign directly to it
+  this.opts.body = this.body || this.opts.body
+
+  let bodyReq
 
   if (typeof this.opts.body === 'string') {
-    body = new Buffer(this.opts.body)
+    bodyReq = new Buffer(this.opts.body)
   } else if (Buffer.isBuffer(this.opts.body)) {
-    body = this.opts.body
+    bodyReq = this.opts.body
   } else if (this.opts.body) {
     throw new Error('body must be either a string or a buffer')
   }
 
-  if (body) {
-    this.opts.headers['Content-Length'] = '' + body.length
+  if (bodyReq) {
+    this.opts.headers['Content-Length'] = '' + bodyReq.length
   }
 
   this._req = Object.keys(this.opts.headers)
@@ -124,8 +130,8 @@ Client.prototype.rebuildRequest = function () {
 
   this._req = new Buffer(this._req + '\r\n', 'utf8')
 
-  if (body) {
-    this._req = Buffer.concat([this._req, body, new Buffer('\r\n')])
+  if (bodyReq) {
+    this._req = Buffer.concat([this._req, bodyReq, new Buffer('\r\n')])
   }
 }
 

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -104,6 +104,12 @@ Client.prototype.setBody = function (newBody) {
   this._rebuild()
 }
 
+Client.prototype.setHeadersAndBody = function (newHeaders, newBody) {
+  this.opts.body = newBody
+
+  this._rebuild()
+}
+
 Client.prototype._rebuild = function () {
   let body
 

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -53,31 +53,7 @@ function Client (opts) {
 
   this._req = `${opts.method} ${opts.path} HTTP/1.1\r\nHost: ${opts.host}\r\nConnection: keep-alive\r\n`
 
-  opts.headers = opts.headers || {}
-
-  var body
-
-  if (typeof opts.body === 'string') {
-    body = new Buffer(opts.body)
-  } else if (Buffer.isBuffer(opts.body)) {
-    body = opts.body
-  } else if (opts.body) {
-    throw new Error('body must be either a string or a buffer')
-  }
-
-  if (body) {
-    opts.headers['Content-Length'] = '' + body.length
-  }
-
-  this._req = Object.keys(opts.headers)
-    .map((key) => `${key}: ${opts.headers[key]}\r\n`)
-    .reduce((acc, str) => acc + str, this._req)
-
-  this._req = new Buffer(this._req + '\r\n', 'utf8')
-
-  if (body) {
-    this._req = Buffer.concat([this._req, body, new Buffer('\r\n')])
-  }
+  this.setHeaders(opts.headers)
 
   this._connect()
 }
@@ -115,6 +91,42 @@ Client.prototype.destroy = function () {
   this.conn.removeAllListeners('end')
   this.conn.on('error', () => {})
   this.conn.destroy()
+}
+
+Client.prototype.setHeaders = function (newHeaders) {
+  this.opts.headers = newHeaders || {}
+  this.rebuildRequest()
+}
+
+Client.prototype.setBody = function (newBody) {
+  this.opts.body = newBody || {}
+  this.rebuildRequest()
+}
+
+Client.prototype.rebuildRequest = function () {
+  let body
+
+  if (typeof this.opts.body === 'string') {
+    body = new Buffer(this.opts.body)
+  } else if (Buffer.isBuffer(this.opts.body)) {
+    body = this.opts.body
+  } else if (this.opts.body) {
+    throw new Error('body must be either a string or a buffer')
+  }
+
+  if (body) {
+    this.opts.headers['Content-Length'] = '' + body.length
+  }
+
+  this._req = Object.keys(this.opts.headers)
+    .map((key) => `${key}: ${this.opts.headers[key]}\r\n`)
+    .reduce((acc, str) => acc + str, this._req)
+
+  this._req = new Buffer(this._req + '\r\n', 'utf8')
+
+  if (body) {
+    this._req = Buffer.concat([this._req, body, new Buffer('\r\n')])
+  }
 }
 
 module.exports = Client

--- a/lib/run.js
+++ b/lib/run.js
@@ -50,19 +50,17 @@ function run (opts, cb) {
   let clients = []
   for (let i = 0; i < opts.connections; i++) {
     let client = new Client(url)
-    client.on('response', record(client))
+    client.on('response', record)
     client.on('connError', onError)
     clients.push(client)
   }
 
-  function record (client) {
-    return function record (statusCode, resBytes, responseTime) {
-      tracker.emit('response', client, statusCode, resBytes, responseTime)
-      statusCodes[(parseInt(statusCode) / 100) - 1] += 1
-      latencies.record(responseTime)
-      bytes += resBytes
-      counter++
-    }
+  function record (statusCode, resBytes, responseTime) {
+    tracker.emit('response', this, statusCode, resBytes, responseTime)
+    statusCodes[(parseInt(statusCode) / 100) - 1] += 1
+    latencies.record(responseTime)
+    bytes += resBytes
+    counter++
   }
 
   function onError () {

--- a/lib/run.js
+++ b/lib/run.js
@@ -10,6 +10,8 @@ function run (opts, cb) {
   cb = cb || noop
 
   const tracker = new EE()
+  tracker.opts = opts
+
   const latencies = new Histogram(1, 10000, 5)
   const requests = new Histogram(1, 1000000, 3)
   const throughput = new Histogram(1, 1000000000, 1)
@@ -48,16 +50,19 @@ function run (opts, cb) {
   let clients = []
   for (let i = 0; i < opts.connections; i++) {
     let client = new Client(url)
-    client.on('response', record)
+    client.on('response', record(client))
     client.on('connError', onError)
     clients.push(client)
   }
 
-  function record (statusCode, resBytes, responseTime) {
-    statusCodes[(parseInt(statusCode) / 100) - 1] += 1
-    latencies.record(responseTime)
-    bytes += resBytes
-    counter++
+  function record (client) {
+    return function record (statusCode, resBytes, responseTime) {
+      tracker.emit('response', client, statusCode, resBytes, responseTime)
+      statusCodes[(parseInt(statusCode) / 100) - 1] += 1
+      latencies.record(responseTime)
+      bytes += resBytes
+      counter++
+    }
   }
 
   function onError () {

--- a/samples/modifying-request.js
+++ b/samples/modifying-request.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const http = require('http')
+const autocannon = require('autocannon')
+
+const server = http.createServer(handle)
+
+server.listen(0, startBench)
+
+function handle (req, res) {
+  res.end('hello world')
+}
+
+function startBench () {
+  const url = 'http://localhost:' + server.address().port
+
+  const instance = autocannon({
+    url: url,
+    connections: 1000,
+    duration: 10
+  }, finishedBench)
+
+  let message = 0
+  // modify the body on future requests
+  instance.on('response', function (client, statusCode, returnBytes, responseTime) {
+    client.setBody('message ' + message++)
+  })
+
+  let headers = 0
+  // modify the headers on future requests
+  // this wipes any existing headers out with the new ones
+  instance.on('response', function (client, statusCode, returnBytes, responseTime) {
+    var newHeaders = {}
+    newHeaders[`header${headers++}`] = `headerValue${headers++}`
+    client.setHeaders(newHeaders)
+  })
+
+  function finishedBench (err, res) {
+    console.log('finished bench', err, res)
+  }
+}

--- a/test/myhttp.test.js
+++ b/test/myhttp.test.js
@@ -186,7 +186,7 @@ test('client supports changing the headers', (t) => {
   client.destroy()
 })
 
-test('client supports changing the headers and body together', (t) => {
+test('client supports changing the headers and body', (t) => {
   t.plan(6)
 
   const opts = server.address()
@@ -204,6 +204,33 @@ test('client supports changing the headers and body together', (t) => {
 
   client.setBody('modified')
   client.setHeaders({header: 'modifiedHeader'})
+
+  t.same(client.opts.body, 'modified', 'body was changed')
+  t.same(client.opts.headers, {'Content-Length': 8, header: 'modifiedHeader'}, 'header was changed')
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nheader: modifiedHeader\r\nContent-Length: 8\r\n\r\nmodified\r\n`),
+  'header changes updated request')
+  client.destroy()
+})
+
+test('client supports changing the headers and body together', (t) => {
+  t.plan(6)
+
+  const opts = server.address()
+  opts.body = 'hello world'
+  opts.method = 'POST'
+
+  const client = new Client(opts)
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nContent-Length: 11\r\n\r\nhello world\r\n`),
+  'request is okay before modifying')
+
+  t.same(client.opts.body, 'hello world', 'body was as expected')
+  t.same(client.opts.headers, {'Content-Length': 11}, 'header was as expected')
+
+  client.setHeadersAndBody({header: 'modifiedHeader'}, 'modified')
 
   t.same(client.opts.body, 'modified', 'body was changed')
   t.same(client.opts.headers, {'Content-Length': 8, header: 'modifiedHeader'}, 'header was changed')

--- a/test/myhttp.test.js
+++ b/test/myhttp.test.js
@@ -185,3 +185,31 @@ test('client supports changing the headers', (t) => {
   'header changes updated request')
   client.destroy()
 })
+
+test('client supports changing the headers and body together', (t) => {
+  t.plan(6)
+
+  const opts = server.address()
+  opts.body = 'hello world'
+  opts.method = 'POST'
+
+  const client = new Client(opts)
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nContent-Length: 11\r\n\r\nhello world\r\n`),
+  'request is okay before modifying')
+
+  t.same(client.opts.body, 'hello world', 'body was as expected')
+  t.same(client.opts.headers, {'Content-Length': 11}, 'header was as expected')
+
+  client.setBody('modified')
+  client.setHeaders({header: 'modifiedHeader'})
+
+  t.same(client.opts.body, 'modified', 'body was changed')
+  t.same(client.opts.headers, {'Content-Length': 8, header: 'modifiedHeader'}, 'header was changed')
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nheader: modifiedHeader\r\nContent-Length: 8\r\n\r\nmodified\r\n`),
+  'header changes updated request')
+  client.destroy()
+})

--- a/test/myhttp.test.js
+++ b/test/myhttp.test.js
@@ -140,3 +140,48 @@ test('client supports sending a body which is a string', (t) => {
     client.destroy()
   })
 })
+
+test('client supports changing the body', (t) => {
+  t.plan(4)
+
+  const opts = server.address()
+  opts.method = 'POST'
+  opts.body = 'hello world'
+
+  const client = new Client(opts)
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nContent-Length: 11\r\n\r\nhello world\r\n`),
+  'request is okay before modifying')
+
+  t.same(client.opts.body, 'hello world', 'body was as expected')
+  client.setBody('modified')
+  t.same(client.opts.body, 'modified', 'body was changed')
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nContent-Length: 8\r\n\r\nmodified\r\n`),
+  'body changes updated request')
+  client.destroy()
+})
+
+test('client supports changing the headers', (t) => {
+  t.plan(4)
+
+  const opts = server.address()
+  opts.method = 'POST'
+
+  const client = new Client(opts)
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\n\r\n`),
+  'request is okay before modifying')
+
+  t.same(client.opts.headers, {}, 'header was as expected')
+  client.setHeaders({header: 'modified'})
+  t.same(client.opts.headers, {header: 'modified'}, 'header was changed')
+
+  t.same(client._req,
+  new Buffer(`POST / HTTP/1.1\r\nHost: localhost:${server.address().port}\r\nConnection: keep-alive\r\nheader: modified\r\n\r\n`),
+  'header changes updated request')
+  client.destroy()
+})


### PR DESCRIPTION
You need to call `.setHeaders(newHeaders)` and `.setBody(newBody)` for modifying these values. The reason you can't shouldn't just assign `.body` is because they are used to build a cached request, and simply overwriting it would mean I would have to un-cache the request and build it every time the client makes the request, because wouldn't be able to effectively and efficiently detect when it has been changed... simply put, its a big no-no for perf. 😄

If you do need to assign directly to the body though, it is possible, you just need to rebuild your request like so:

```js
const instance = autocannon({
    url: url,
    connections: 1000,
    duration: 10
  }, finishedBench)

  instance.on('response', function (client, statusCode, returnBytes, responseTime) {
    client.setHeaders({ .. })
    client.body = ...
    client.rebuildRequest()
  })
```

However, the preferred method of use is:
```js
const instance = autocannon({
    url: url,
    connections: 1000,
    duration: 10
  }, finishedBench)

  instance.on('response', function (client, statusCode, returnBytes, responseTime) {
    client.setHeaders(...)
    client.setBody(...)
  })
```

Also, `.headers` cant be reassigned to, as I'm not what the `.headers` variable are for.