### PR TITLE
Fixed #16: can now pass customiseRequest to build custom requests per connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Start autocannon against the given target.
     * `method`: The http method to use. _OPTIONAL_ `default: 'GET'`.
     * `body`: A `String` or a `Buffer` containing the body of the request. Leave undefined for an empty body. _OPTIONAL_ default: `undefined`.
     * `headers`: An `Object` containing the headers of the request. _OPTIONAL_ default: `{}`.
+    * `customiseRequest`: A `Function` which will be passed the `Client` object for each connection to be made. This can be used to customise each individual connection headers and body using the API shown below. The changes you make to the client in this function will take precedence over the default `body` and `headers` you pass in here. There is an example of this in the samples folder. _OPTIONAL_ default: `function noop () {}`.
 * `cb`: The callback which is called on completion of the benchmark. Takes the following params. _OPTIONAL_.
     * `err`: If there was an error encountered with the run.
     * `results`: The results of the run.

--- a/lib/myhttp.js
+++ b/lib/myhttp.js
@@ -16,6 +16,7 @@ function Client (opts) {
     return new Client(opts)
   }
 
+  opts.customiseRequest = opts.customiseRequest || noop
   opts.pipelining = opts.pipelining || 1
   opts.port = opts.port || 80
   opts.method = opts.method || 'GET'
@@ -64,6 +65,8 @@ function Client (opts) {
   this.baseReq = `${opts.method} ${opts.path} HTTP/1.1\r\nHost: ${opts.host}\r\nConnection: keep-alive\r\n`
 
   this.setHeaders(opts.headers)
+
+  opts.customiseRequest(this)
 
   this._connect()
 }
@@ -147,5 +150,7 @@ Client.prototype._rebuild = function () {
     this._req = Buffer.concat([this._req, body, new Buffer('\r\n')])
   }
 }
+
+function noop () {}
 
 module.exports = Client

--- a/lib/run.js
+++ b/lib/run.js
@@ -63,6 +63,7 @@ function run (opts, cb) {
   url.method = opts.method
   url.body = opts.body
   url.headers = opts.headers
+  url.customiseRequest = opts.customiseRequest
 
   let clients = []
   for (let i = 0; i < opts.connections; i++) {

--- a/samples/customise-individual-connection.js
+++ b/samples/customise-individual-connection.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const http = require('http')
+const autocannon = require('autocannon')
+
+const server = http.createServer(handle)
+
+server.listen(0, startBench)
+
+function handle (req, res) {
+  res.end('hello world')
+}
+
+function startBench () {
+  const url = 'http://localhost:' + server.address().port
+
+  autocannon({
+    url: url,
+    connections: 1000,
+    duration: 10,
+    customiseRequest: customiseRequest
+  }, finishedBench)
+
+  let connection = 0
+
+  function customiseRequest (client) {
+    client.setBody('connection number', connection++)
+  }
+
+  function finishedBench (err, res) {
+    console.log('finished bench', err, res)
+  }
+}


### PR DESCRIPTION
This has the code, the docs and a sample. No unit tests right now however, I'm unsure how to test this.

fixes #16