### PR TITLE
kOnHeaders bugfix

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -50,7 +50,7 @@ function Client (opts) {
   }
 
   this.timeoutTicker = retimer(handleTimeout, this.timeout)
-
+  this.parser[HTTPParser.kOnHeaders] = () => {}
   this.parser[HTTPParser.kOnHeadersComplete] = (opts) => {
     this.emit('headers', opts)
     this.resData[this.cer].headers = opts

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,6 +19,23 @@ function startServer () {
   return server
 }
 
+function startTrailerServer () {
+  const server = http.createServer(handle)
+
+  function handle (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain', 'Trailer': 'Content-MD5' })
+    res.write('hello ')
+    res.addTrailers({'Content-MD5': '7895bf4b8828b55ceaf47747b4bca667'})
+    res.end('world')
+  }
+
+  server.listen(0)
+
+  server.unref()
+
+  return server
+}
+
 // this server won't reply to requests
 function startTimeoutServer () {
   const server = http.createServer(() => {})
@@ -53,3 +70,4 @@ function startHttpsServer () {
 module.exports.startServer = startServer
 module.exports.startTimeoutServer = startTimeoutServer
 module.exports.startHttpsServer = startHttpsServer
+module.exports.startTrailerServer = startTrailerServer


### PR DESCRIPTION
If a response has trailers, it will trigger the following:

https://github.com/creationix/http-parser-js/blob/master/http-parser.js#L353

We need a noop for kOnHeaders otherwise autocannon will throw when a response has trailers

cc @mcollina 