### PR TITLE
Bump max throughput to 100GB/s

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -34,7 +34,7 @@ function run (opts, cb) {
 
   const latencies = new Histogram(1, 10000, 5)
   const requests = new Histogram(1, 1000000, 3)
-  const throughput = new Histogram(1, 1000000000, 1)
+  const throughput = new Histogram(1, 100000000000, 1)
   const statusCodes = [
     0, // 1xx
     0, // 2xx


### PR DESCRIPTION
Bumps max throughput to 100GB/s.

Fixes: https://github.com/mcollina/autocannon/issues/82