### PR TITLE
Feature/fix header parsing

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -12,8 +12,8 @@ const track = require('./lib/progressTracker')
 module.exports = run
 module.exports.track = track
 
-function start () {
-  const argv = minimist(process.argv.slice(2), {
+function parseArguments (argvs) {
+  const argv = minimist(argvs, {
     boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement'],
     alias: {
       connections: 'c',
@@ -90,6 +90,10 @@ function start () {
     }, {})
   }
 
+  return argv
+}
+
+function start (argv) {
   const tracker = run(argv)
 
   tracker.on('done', (result) => {
@@ -113,5 +117,11 @@ function start () {
 }
 
 if (require.main === module) {
-  start()
+  const argv = parseArguments(process.argv.slice(2))
+  if (argv) start(argv)
+}
+
+module.exports = {
+  start: start,
+  parseArguments: parseArguments
 }

--- a/autocannon.js
+++ b/autocannon.js
@@ -84,8 +84,8 @@ function parseArguments (argvs) {
     }
 
     argv.headers = argv.headers.reduce((obj, header) => {
-      const split = header.split('=')
-      obj[split[0]] = split[1]
+      const index = header.indexOf('=')
+      obj[header.slice(0, index)] = header.slice(index + 1)
       return obj
     }, {})
   }

--- a/test/argumentParsing.test.js
+++ b/test/argumentParsing.test.js
@@ -41,3 +41,16 @@ test('parse argument with multiple headers', (t) => {
   })
   t.equal(args.method, 'GET')
 })
+
+test('parse argument with "=" in value header', (t) => {
+  t.plan(1)
+
+  var args = Autocannon.parseArguments([
+    '-H', 'header1=foo=bar',
+    'http://localhost/foo/bar'
+  ])
+
+  t.strictSame(args.headers, {
+    'header1': 'foo=bar'
+  })
+})

--- a/test/argumentParsing.test.js
+++ b/test/argumentParsing.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const test = require('tap').test
+const Autocannon = require('../autocannon')
+
+test('parse argument', (t) => {
+  t.plan(4)
+
+  var args = Autocannon.parseArguments([
+    '-H', 'X-Http-Method-Override=GET',
+    '-m', 'POST',
+    '-b', 'the body',
+    'http://localhost/foo/bar'
+  ])
+
+  t.equal(args.url, 'http://localhost/foo/bar')
+  t.strictSame(args.headers, { 'X-Http-Method-Override': 'GET' })
+  t.equal(args.method, 'POST')
+  t.equal(args.body, 'the body')
+})
+
+test('parse argument with multiple headers', (t) => {
+  t.plan(3)
+
+  var args = Autocannon.parseArguments([
+    '-H', 'header1=value1',
+    '-H', 'header2=value2',
+    '-H', 'header3=value3',
+    '-H', 'header4=value4',
+    '-H', 'header5=value5',
+    'http://localhost/foo/bar'
+  ])
+
+  t.equal(args.url, 'http://localhost/foo/bar')
+  t.strictSame(args.headers, {
+    'header1': 'value1',
+    'header2': 'value2',
+    'header3': 'value3',
+    'header4': 'value4',
+    'header5': 'value5'
+  })
+  t.equal(args.method, 'GET')
+})


### PR DESCRIPTION
A bug occurred when the header value contains a "=".

Three commits:
1. Refactorize the "autocannon.js" file in order to be tested. Tests also introduced
2. Write a test that fails
3. Fix the test
