### PR TITLE
README: remove non existent benchmarks header from toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ On _my_ box, *autocannon* can produce more load than `wrk` and `wrk2`.
 
 * [Installation](#install)
 * [Usage](#usage)
-* [Benchmarks](#benchmarks)
 * [API](#api)
 * [Acknowledgements](#acknowledgements)
 * [License](#license)


### PR DESCRIPTION
This patch removes Benchmarks header link from table of content as the
section isn't present anymore.