### PR TITLE
Fix bytes/sec max NaN output

### DIFF
--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -164,7 +164,7 @@ function asRow (name, stat) {
     name,
     stat.average,
     stat.stddev,
-    Math.floor(stat.max * 100) / 100
+    stat.max
   ]
 }
 


### PR DESCRIPTION
`stat.max` have already been converted to a human readable string containing the appropriate unit, so there's no need to format it further.