### PR TITLE
Reintroduce max two decimals in max column output

### DIFF
--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -164,7 +164,7 @@ function asRow (name, stat) {
     name,
     stat.average,
     stat.stddev,
-    stat.max
+    typeof stat.max === 'string' ? stat.max : Math.floor(stat.max * 100) / 100
   ]
 }
 


### PR DESCRIPTION
Bug was introduced in #117