### PR TITLE
Clean up use of teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pre-commit": "^1.1.2",
     "split2": "^2.1.0",
     "standard": "^10.0.0",
-    "tap": "^11.0.0"
+    "tap": "^11.1.0"
   },
   "dependencies": {
     "chalk": "^2.0.0",

--- a/test/cli-ipc.test.js
+++ b/test/cli-ipc.test.js
@@ -25,8 +25,12 @@ if (!win) {
   // If not Windows we can predict exactly how many lines there will be. On
   // Windows we rely on t.end() being called.
   t.plan(lines.length)
-  t.tearDown(teardown)
 }
+
+t.autoend(false)
+t.tearDown(function () {
+  child.kill()
+})
 
 const socketPath = win
   ? path.join('\\\\?\\pipe', process.cwd(), 'autocannon-' + Date.now())
@@ -61,7 +65,6 @@ child
         // in case there are no more lines.
         failsafeTimer = setTimeout(function () {
           t.end()
-          teardown()
         }, 1000)
       }
     } else if (!errorLine && win) {
@@ -75,12 +78,7 @@ child
       const errors = Number(match[1])
       t.ok(errors / 15000 < 0.01, `should have less than 1% errors on Windows (had ${errors} errors)`)
       t.end()
-      teardown()
     } else {
       throw new Error('Unexpected line: ' + JSON.stringify(line))
     }
   })
-
-function teardown () {
-  child.kill()
-}


### PR DESCRIPTION
The new tap v11.1.0 improves the ability to disable `autoend`, which means we can use t.tearDown even if we don't know call t.plan again.

See:
https://github.com/tapjs/node-tap/commit/fcf70aad8582d434658b8d3fe794e6ee463bcd2d

P.S. this was JUST released, so I unfortunately couldn't have included this in my last PR 😅 