### PR TITLE
Allow use of http host and path during IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ Usage: autocannon [opts] URL
 
 URL is any valid http or https url.
 
-For IPC, the url can be substituted by a path to a Unix Domain Socket or
-a Windows Named Pipe.
-
 Available options:
 
   -c/--connections NUM
@@ -53,6 +50,8 @@ Available options:
         The number of seconds to run the autocannnon. default: 10.
   -a/--amount NUM
         The amount of requests to make before exiting the benchmark. If set, duration is ignored.
+  -S/--socketPath
+        A path to a Unix Domain Socket or a Windows Named Pipe. A URL is still required in order to send the correct Host header and path.
   -m/--method METHOD
         The http method to use. default: 'GET'.
   -t/--timeout NUM
@@ -119,8 +118,8 @@ autocannon({
 Start autocannon against the given target.
 
 * `opts`: Configuration options for the autocannon instance. This can have the following attributes. _REQUIRED_.
-    * `url`: The given target. Can be http or https. _REQUIRED unless `socketPath` is provided_.
-    * `socketPath`:  Unix Domain Socket (use one of `url` or `socketPath`). _REQUIRED unless `url` is provided_.
+    * `url`: The given target. Can be http or https. _REQUIRED_.
+    * `socketPath`: A path to a Unix Domain Socket or a Windows Named Pipe. A `url` is still required in order to send the correct Host header and path. _OPTIONAL_.
     * `connections`: The number of concurrent connections. _OPTIONAL_ default: `10`.
     * `duration`: The number of seconds to run the autocannon. Can be a [timestring](https://www.npmjs.com/package/timestring). _OPTIONAL_ default: `10`.
     * `amount`: A `Number` stating the amount of requests to make before ending the test. This overrides duration and takes precedence, so the test won't end until the amount of requests needed to be completed are completed. _OPTIONAL_.

--- a/autocannon.js
+++ b/autocannon.js
@@ -41,6 +41,7 @@ function parseArguments (argvs) {
       version: 'v',
       forever: 'f',
       idReplacement: 'I',
+      socketPath: 'S',
       help: 'h'
     },
     default: {
@@ -58,11 +59,7 @@ function parseArguments (argvs) {
     }
   })
 
-  if (isIPC(argv._[0])) {
-    argv.socketPath = argv._[0]
-  } else {
-    argv.url = argv._[0]
-  }
+  argv.url = argv._[0]
 
   // support -n to disable the progress bar and results table
   if (argv.n) {
@@ -76,7 +73,7 @@ function parseArguments (argvs) {
     return
   }
 
-  if (!(argv.url || argv.socketPath) || argv.help) {
+  if (!argv.url || argv.help) {
     console.error(help)
     return
   }
@@ -126,10 +123,6 @@ function start (argv) {
   process.once('SIGINT', () => {
     tracker.stop()
   })
-}
-
-function isIPC (path) {
-  return (/\.sock$/.test(path) && fs.existsSync(path)) || /^\\\\[?.]\\pipe/.test(path)
 }
 
 if (require.main === module) {

--- a/help.txt
+++ b/help.txt
@@ -2,8 +2,6 @@ Usage: autocannon [opts] URL
 
 URL is any valid http or https url.
 
-For IPC, the url can be substituted by a path to a Unix Domain Socket or a Windows Named Pipe.
-
 Available options:
 
   -c/--connections NUM
@@ -14,6 +12,8 @@ Available options:
         The number of seconds to run the autocannnon. default: 10.
   -a/--amount NUM
         The amount of requests to make before exiting the benchmark. If set, duration is ignored.
+  -S/--socketPath
+        A path to a Unix Domain Socket or a Windows Named Pipe. A URL is still required in order to send the correct Host header and path.
   -m/--method METHOD
         The http method to use. default: 'GET'.
   -t/--timeout NUM

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -34,6 +34,7 @@ function track (instance, opts) {
 
   instance.on('start', () => {
     if (opts.renderProgressBar) {
+      const socketPath = iOpts.socketPath ? ` (${iOpts.socketPath})` : ''
       let msg = `${iOpts.connections} connections`
 
       if (iOpts.pipelining > 1) {
@@ -41,11 +42,11 @@ function track (instance, opts) {
       }
 
       if (!iOpts.amount) {
-        logToStream(`Running ${iOpts.duration}s test @ ${iOpts.url}\n${msg}\n`)
+        logToStream(`Running ${iOpts.duration}s test @ ${iOpts.url}${socketPath}\n${msg}\n`)
 
         durationProgressBar = trackDuration(instance, opts, iOpts)
       } else {
-        logToStream(`Running ${iOpts.amount} requests test @ ${iOpts.url}\n${msg}\n`)
+        logToStream(`Running ${iOpts.amount} requests test @ ${iOpts.url}${socketPath}\n${msg}\n`)
 
         amountProgressBar = trackAmount(instance, opts, iOpts)
       }

--- a/lib/run.js
+++ b/lib/run.js
@@ -78,10 +78,8 @@ function run (opts, cb) {
   // is done
   tracker.opts = opts
 
-  const ipc = !!opts.socketPath
-
-  if (!ipc && opts.url.indexOf('http') !== 0) opts.url = 'http://' + opts.url
-  const url = ipc ? {socketPath: opts.socketPath} : URL.parse(opts.url)
+  if (opts.url.indexOf('http') !== 0) opts.url = 'http://' + opts.url
+  const url = URL.parse(opts.url)
 
   let counter = 0
   let bytes = 0
@@ -109,6 +107,7 @@ function run (opts, cb) {
   url.responseMax = amount || opts.maxConnectionRequests || opts.maxOverallRequests
   url.rate = opts.connectionRate || opts.overallRate
   url.idReplacement = opts.idReplacement
+  url.socketPath = opts.socketPath
 
   let clients = []
   initialiseClients(clients)

--- a/test/cli-ipc.test.js
+++ b/test/cli-ipc.test.js
@@ -10,7 +10,7 @@ const helper = require('./helper')
 const win = process.platform === 'win32'
 
 const lines = [
-  /Running 1s test @ .*$/,
+  /Running 1s test @ http:\/\/example.com\/foo \([^)]*\)$/,
   /10 connections.*$/,
   /$/,
   /Stat.*Avg.*Stdev.*Max.*$/,
@@ -38,7 +38,7 @@ const socketPath = win
 
 helper.startServer({socketPath})
 
-const child = childProcess.spawn(process.execPath, [path.join(__dirname, '..'), '-d', '1', socketPath], {
+const child = childProcess.spawn(process.execPath, [path.join(__dirname, '..'), '-d', '1', '-S', socketPath, 'example.com/foo'], {
   cwd: __dirname,
   env: process.env,
   stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -224,7 +224,7 @@ test('run should recognise valid urls without http at the start', (t) => {
   })
 })
 
-test('run should accept a unix socket/windows pipe instead of a url', (t) => {
+test('run should accept a unix socket/windows pipe', (t) => {
   t.plan(11)
 
   const socketPath = process.platform === 'win32'
@@ -234,6 +234,7 @@ test('run should accept a unix socket/windows pipe instead of a url', (t) => {
   helper.startServer({socketPath})
 
   run({
+    url: 'localhost',
     socketPath,
     connections: 2,
     duration: 2


### PR DESCRIPTION
Previously the Host header was always `localhost` when connecting to a Unix Domain Socket or a Windows Named Pipe. It was also not possible to use any other path than `/`.

With this commit the URL is always treated as a URL and if you want to supply a Unix Domain Socket or Windows Named Pipe, you instead have to provide it using `--socketPath` (aliased `-S`).