### PR TITLE
fix default option issue

### DIFF
--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -1,0 +1,20 @@
+const defaultOptions = {
+  headers: {},
+  body: Buffer.alloc(0),
+  method: 'GET',
+  duration: 10,
+  connections: 10,
+  pipelining: 1,
+  timeout: 10,
+  maxConnectionRequests: 0,
+  maxOverallRequests: 0,
+  connectionRate: 0,
+  overallRate: 0,
+  amount: 0,
+  reconnectRate: 0,
+  forever: false,
+  idReplacement: false,
+  requests: [{}]
+}
+
+module.exports = defaultOptions

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,32 +3,15 @@
 const EE = require('events').EventEmitter
 const URL = require('url')
 const hdr = require('hdr-histogram-js')
+const clone = require('clone')
 const timestring = require('timestring')
 const Client = require('./httpClient')
+const DefaultOptions = require('./defaultOptions')
 const xtend = require('xtend')
 const histUtil = require('hdr-histogram-percentiles-obj')
 const reInterval = require('reinterval')
 const histAsObj = histUtil.histAsObj
 const addPercentiles = histUtil.addPercentiles
-
-const defaultOptions = {
-  headers: {},
-  body: Buffer.alloc(0),
-  method: 'GET',
-  duration: 10,
-  connections: 10,
-  pipelining: 1,
-  timeout: 10,
-  maxConnectionRequests: 0,
-  maxOverallRequests: 0,
-  connectionRate: 0,
-  overallRate: 0,
-  amount: 0,
-  reconnectRate: 0,
-  forever: false,
-  idReplacement: false,
-  requests: [{}]
-}
 
 function run (opts, cb) {
   const cbPassedIn = (typeof cb === 'function')
@@ -69,7 +52,7 @@ function run (opts, cb) {
     0  // 5xx
   ]
 
-  opts = xtend(defaultOptions, opts)
+  opts = xtend(clone(DefaultOptions), opts)
 
   // do error checking, if error, return
   if (checkOptsForErrors()) return

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "chalk": "^2.0.0",
+    "clone": "^2.1.1",
     "color-support": "^1.1.1",
     "deep-extend": "^0.5.0",
     "hdr-histogram-js": "^1.0.0",

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -3,7 +3,9 @@
 const os = require('os')
 const path = require('path')
 const test = require('tap').test
+const clone = require('clone')
 const run = require('../lib/run')
+const defaultOptions = require('../lib/defaultOptions')
 const helper = require('./helper')
 const server = helper.startServer()
 
@@ -279,3 +281,16 @@ for (let i = 1; i <= 5; i++) {
     })
   })
 }
+
+test('run should not modify default options', (t) => {
+  const origin = clone(defaultOptions)
+  run({
+    url: 'http://localhost:' + server.address().port,
+    connections: 2,
+    duration: 2
+  }, function (err, result) {
+    t.error(err)
+    t.deepEqual(defaultOptions, origin, 'calling run function does not modify default options')
+    t.end()
+  })
+})


### PR DESCRIPTION
I get something wrong when I run two autocannon benchmark at same time. However if I run these benchmarks separately it works fine.
example:
```js
const autocannon = require('autocannon');
const util = require('util');

const autocannonFunc = util.promisify(autocannon);

function setupClient {
    ...
}

async function login() {
  try {
    return await autocannonFunc({
      url: 'http://192.168.0.245:10000/login',
      connections: 15,
      pipelining: 1,
      amount: 15,
      bailout: 1,
      method: 'POST',
      setupClient,
    });
  } catch(err) {
      ...
  }
}

async function register() {
  try {
    return await autocannonFunc({
      url: 'http://192.168.0.245:8888/register',
      connections: 1,
      pipelining: 10,
      amount: 20,
      bailout: 1,
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',
      },
      body: JSON.stringify(body),
    });
  } catch(err) {
      ...
  }
}

Promise.all([login(), register()])
```
run above code ,  second autocannon instance will return abnormal 5xx code . I figure out that first calling of  `run()` function change the `requests` field of `defaultOptions` object, cause second calling failed. So I think it should be fine to move `defaultOptions` into function `run()` block to avoid the side effect. 