### PR TITLE
Added optional server name for the SNI TLS extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Available options:
         Print the output as newline delimited json. This will cause the progress bar and results not to be rendered. default: false.
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
+  -s/--sniServerName
+        Server name for the SNI (Server Name Indication) TLS extension.
   -v/--version
         Print the version number.
   -h/--help
@@ -139,6 +141,7 @@ Start autocannon against the given target.
     * `requests`: An `Array` of `Object`s which represents the sequence of requests to make while benchmarking. Can be used in conjunction with the `body`, `headers` and `method` params above. The `Object`s in this array can have `body`, `headers`, `method`, or `path` attributes, which overwrite those that are passed in this `opts` object. Therefore, the ones in this (`opts`) object take precedence and should be viewed as defaults. Check the samples folder for an example of how this might be used. _OPTIONAL_.
     * `idReplacement`: A `Boolean` which enables the replacement of `[<id>]` tags within the request body with a randomly generated ID, allowing for unique fields to be sent with requests. Check out [an example of programmatic usage](./samples/using-id-replacement.js) can be found in the samples. _OPTIONAL_ default: `false`
     * `forever`: A `Boolean` which allows you to setup an instance of autocannon that restarts indefinitely after emiting results with the `done` event. Useful for efficiently restarting your instance. To stop running forever, you must cause a `SIGINT` or call the `.stop()` function on your instance. _OPTIONAL_ default: `false`
+    * `sniServerName`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: `undefined`.
 * `cb`: The callback which is called on completion of a benchmark. Takes the following params. _OPTIONAL_.
     * `err`: If there was an error encountered with the run.
     * `results`: The results of the run.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Available options:
         Print the output as newline delimited json. This will cause the progress bar and results not to be rendered. default: false.
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
-  -s/--sniServerName
+  -s/--servername
         Server name for the SNI (Server Name Indication) TLS extension.
   -v/--version
         Print the version number.
@@ -141,7 +141,7 @@ Start autocannon against the given target.
     * `requests`: An `Array` of `Object`s which represents the sequence of requests to make while benchmarking. Can be used in conjunction with the `body`, `headers` and `method` params above. The `Object`s in this array can have `body`, `headers`, `method`, or `path` attributes, which overwrite those that are passed in this `opts` object. Therefore, the ones in this (`opts`) object take precedence and should be viewed as defaults. Check the samples folder for an example of how this might be used. _OPTIONAL_.
     * `idReplacement`: A `Boolean` which enables the replacement of `[<id>]` tags within the request body with a randomly generated ID, allowing for unique fields to be sent with requests. Check out [an example of programmatic usage](./samples/using-id-replacement.js) can be found in the samples. _OPTIONAL_ default: `false`
     * `forever`: A `Boolean` which allows you to setup an instance of autocannon that restarts indefinitely after emiting results with the `done` event. Useful for efficiently restarting your instance. To stop running forever, you must cause a `SIGINT` or call the `.stop()` function on your instance. _OPTIONAL_ default: `false`
-    * `sniServerName`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: `undefined`.
+    * `servername`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: `undefined`.
 * `cb`: The callback which is called on completion of a benchmark. Takes the following params. _OPTIONAL_.
     * `err`: If there was an error encountered with the run.
     * `results`: The results of the run.

--- a/autocannon.js
+++ b/autocannon.js
@@ -29,6 +29,7 @@ function parseArguments (argvs) {
       method: 'm',
       headers: ['H', 'header'],
       body: 'b',
+      sniServerName: 's',
       bailout: 'B',
       input: 'i',
       maxConnectionRequests: 'M',

--- a/autocannon.js
+++ b/autocannon.js
@@ -29,7 +29,7 @@ function parseArguments (argvs) {
       method: 'm',
       headers: ['H', 'header'],
       body: 'b',
-      sniServerName: 's',
+      servername: 's',
       bailout: 'B',
       input: 'i',
       maxConnectionRequests: 'M',

--- a/help.txt
+++ b/help.txt
@@ -50,6 +50,8 @@ Available options:
         Print the output as newline delimited json. This will cause the progress bar and results not to be rendered. default: false.
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
+  -s/--sniServerName
+        Server name for the SNI (Server Name Indication) TLS extension.
   -v/--version
         Print the version number.
   -h/--help

--- a/help.txt
+++ b/help.txt
@@ -50,7 +50,7 @@ Available options:
         Print the output as newline delimited json. This will cause the progress bar and results not to be rendered. default: false.
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
-  -s/--sniServerName
+  -s/--servername
         Server name for the SNI (Server Name Indication) TLS extension.
   -v/--version
         Print the version number.

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -14,7 +14,8 @@ const defaultOptions = {
   reconnectRate: 0,
   forever: false,
   idReplacement: false,
-  requests: [{}]
+  requests: [{}],
+  sniServerName: undefined
 }
 
 module.exports = defaultOptions

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -15,7 +15,7 @@ const defaultOptions = {
   forever: false,
   idReplacement: false,
   requests: [{}],
-  sniServerName: undefined
+  servername: undefined
 }
 
 module.exports = defaultOptions

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -106,7 +106,7 @@ Client.prototype._connect = function () {
     if (this.ipc) {
       this.conn = tls.connect(this.opts.socketPath, { rejectUnauthorized: false })
     } else {
-      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername: this.opts.sniServerName })
+      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername: this.opts.servername })
     }
   } else {
     if (this.ipc) {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -106,7 +106,7 @@ Client.prototype._connect = function () {
     if (this.ipc) {
       this.conn = tls.connect(this.opts.socketPath, { rejectUnauthorized: false })
     } else {
-      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false })
+      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername: this.opts.sniServerName })
     }
   } else {
     if (this.ipc) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,6 +91,7 @@ function run (opts, cb) {
   url.rate = opts.connectionRate || opts.overallRate
   url.idReplacement = opts.idReplacement
   url.socketPath = opts.socketPath
+  url.sniServerName = opts.sniServerName
 
   let clients = []
   initialiseClients(clients)

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,7 +91,7 @@ function run (opts, cb) {
   url.rate = opts.connectionRate || opts.overallRate
   url.idReplacement = opts.idReplacement
   url.socketPath = opts.socketPath
-  url.sniServerName = opts.sniServerName
+  url.servername = opts.servername
 
   let clients = []
   initialiseClients(clients)

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -6,6 +6,7 @@ const helper = require('./helper')
 const server = helper.startServer()
 const timeoutServer = helper.startTimeoutServer()
 const httpsServer = helper.startHttpsServer()
+const tlsServer = helper.startTlsServer()
 const trailerServer = helper.startTrailerServer()
 const bl = require('bl')
 
@@ -35,6 +36,41 @@ test('client calls a https server twice', (t) => {
   client.on('response', (statusCode, length) => {
     t.equal(statusCode, 200, 'status code matches')
     t.ok(length > 'hello world'.length, 'length includes the headers')
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
+test('client calls a tls server without SNI servername twice', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', '', 'Content-Length', '0'])
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
+test('client calls a tls server with SNI servername twice', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  opts.sniServerName = 'example.com'
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', opts.sniServerName, 'Content-Length', '0'])
     if (count++ > 0) {
       client.destroy()
     }

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -64,13 +64,13 @@ test('client calls a tls server with SNI servername twice', (t) => {
 
   var opts = tlsServer.address()
   opts.protocol = 'https:'
-  opts.sniServerName = 'example.com'
+  opts.servername = 'example.com'
   const client = new Client(opts)
   let count = 0
 
   client.on('headers', (response) => {
     t.equal(response.statusCode, 200, 'status code matches')
-    t.deepEqual(response.headers, ['X-servername', opts.sniServerName, 'Content-Length', '0'])
+    t.deepEqual(response.headers, ['X-servername', opts.servername, 'Content-Length', '0'])
     if (count++ > 0) {
       client.destroy()
     }


### PR DESCRIPTION
Server Name Indication (SNI) is an extension to TLS by which a client indicates which hostname it is attempting to connect to at the start of the handshaking process. This allows a server to present multiple certificates on the same IP address.

https://en.wikipedia.org/wiki/Server_Name_Indication