### PR TITLE
Target localhost by default if $PORT is set, closes #146.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm i autocannon --save
 Usage: autocannon [opts] URL
 
 URL is any valid http or https url.
+If the PORT environment variable is set, the URL can be a path. In that case 'http://localhost:$PORT/path' will be used as the URL.
 
 Available options:
 

--- a/autocannon.js
+++ b/autocannon.js
@@ -5,6 +5,7 @@
 const minimist = require('minimist')
 const fs = require('fs')
 const path = require('path')
+const URL = require('url').URL
 const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
 const run = require('./lib/run')
 const track = require('./lib/progressTracker')
@@ -63,6 +64,13 @@ function parseArguments (argvs) {
   })
 
   argv.url = argv._[0]
+
+  // If PORT is set (like by `0x`), target `localhost:PORT/path` by default.
+  // This allows doing:
+  //     0x --on-port 'autocannon /path' -- node server.js
+  if (process.env.PORT) {
+    argv.url = new URL(argv.url, `http://localhost:${process.env.PORT}`).href
+  }
 
   // support -n to disable the progress bar and results table
   if (argv.n) {

--- a/autocannon.js
+++ b/autocannon.js
@@ -65,11 +65,26 @@ function parseArguments (argvs) {
 
   argv.url = argv._[0]
 
-  // If PORT is set (like by `0x`), target `localhost:PORT/path` by default.
-  // This allows doing:
+  // if PORT is set (like by `0x`), target `localhost:PORT/path` by default.
+  // this allows doing:
   //     0x --on-port 'autocannon /path' -- node server.js
   if (process.env.PORT) {
     argv.url = new URL(argv.url, `http://localhost:${process.env.PORT}`).href
+  }
+  // Add http:// if it's not there and this is not a /path
+  if (argv.url.indexOf('http') !== 0 && argv.url[0] !== '/') {
+    argv.url = `http://${argv.url}`
+  }
+
+  // check that the URL is valid.
+  try {
+    new URL(argv.url) // eslint-disable-line no-new
+  } catch (err) {
+    console.error(err.message)
+    console.error('')
+    console.error('When targeting a path without a hostname, the PORT environment variable must be available.')
+    console.error('Use a full URL or set the PORT variable.')
+    process.exit(1)
   }
 
   // support -n to disable the progress bar and results table

--- a/autocannon.js
+++ b/autocannon.js
@@ -10,6 +10,11 @@ const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
 const run = require('./lib/run')
 const track = require('./lib/progressTracker')
 
+if (typeof URL !== 'function') {
+  console.error('autocannon requires the WHATWG URL API, but it is not available. Please upgrade to Node 6.13+.')
+  process.exit(1)
+}
+
 module.exports = run
 module.exports.track = track
 

--- a/autocannon.js
+++ b/autocannon.js
@@ -70,6 +70,23 @@ function parseArguments (argvs) {
 
   argv.url = argv._[0]
 
+  // support -n to disable the progress bar and results table
+  if (argv.n) {
+    argv.renderProgressBar = false
+    argv.renderResultsTable = false
+  }
+
+  if (argv.version) {
+    console.log('autocannon', 'v' + require('./package').version)
+    console.log('node', process.version)
+    return
+  }
+
+  if (!argv.url || argv.help) {
+    console.error(help)
+    return
+  }
+
   // if PORT is set (like by `0x`), target `localhost:PORT/path` by default.
   // this allows doing:
   //     0x --on-port 'autocannon /path' -- node server.js
@@ -90,23 +107,6 @@ function parseArguments (argvs) {
     console.error('When targeting a path without a hostname, the PORT environment variable must be available.')
     console.error('Use a full URL or set the PORT variable.')
     process.exit(1)
-  }
-
-  // support -n to disable the progress bar and results table
-  if (argv.n) {
-    argv.renderProgressBar = false
-    argv.renderResultsTable = false
-  }
-
-  if (argv.version) {
-    console.log('autocannon', 'v' + require('./package').version)
-    console.log('node', process.version)
-    return
-  }
-
-  if (!argv.url || argv.help) {
-    console.error(help)
-    return
   }
 
   if (argv.input) {

--- a/help.txt
+++ b/help.txt
@@ -1,6 +1,7 @@
 Usage: autocannon [opts] URL
 
 URL is any valid http or https url.
+If the PORT environment variable is set, the URL can be a path. In that case 'http://localhost:$PORT/path' will be used as the URL.
 
 Available options:
 

--- a/test/envPort.test.js
+++ b/test/envPort.test.js
@@ -18,7 +18,7 @@ const lines = [
   /.* requests in \d+s, .* read/
 ]
 
-t.plan(lines.length * 2 + 1)
+t.plan(lines.length * 2 + 2)
 
 const server = helper.startServer()
 const port = server.address().port
@@ -48,3 +48,14 @@ child
   .on('end', () => {
     t.ok(server.autocannonConnects > 0, 'targeted the correct port')
   })
+
+const noPortChild = childProcess.spawn(process.execPath, [path.join(__dirname, '..'), url], {
+  cwd: __dirname,
+  env: process.env,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: false
+})
+
+noPortChild.on('exit', (code) => {
+  t.equal(code, 1, 'should exit with error when a hostless URL is passed and no PORT var is available')
+})

--- a/test/envPort.test.js
+++ b/test/envPort.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const t = require('tap')
+const split = require('split2')
+const path = require('path')
+const childProcess = require('child_process')
+const helper = require('./helper')
+
+const lines = [
+  /Running 1s test @ .*$/,
+  /10 connections.*$/,
+  /$/,
+  /Stat.*Avg.*Stdev.*Max.*$/,
+  /Latency \(ms\).*$/,
+  /Req\/Sec.*$/,
+  /Bytes\/Sec.*$/,
+  /$/,
+  /.* requests in \d+s, .* read/
+]
+
+t.plan(lines.length * 2 + 1)
+
+const server = helper.startServer()
+const port = server.address().port
+const url = '/path' // no hostname
+
+const child = childProcess.spawn(process.execPath, [path.join(__dirname, '..'), '-d', '1', url], {
+  cwd: __dirname,
+  env: Object.assign({}, process.env, {
+    PORT: port
+  }),
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: false
+})
+
+t.tearDown(() => {
+  child.kill()
+})
+
+child
+  .stderr
+  .pipe(split())
+  .on('data', (line) => {
+    const regexp = lines.shift()
+    t.ok(regexp, 'we are expecting this line')
+    t.ok(regexp.test(line), 'line matches ' + regexp)
+  })
+  .on('end', () => {
+    t.ok(server.autocannonConnects > 0, 'targeted the correct port')
+  })


### PR DESCRIPTION
If the `$PORT` env variable is set, the URL defaults to
`localhost:PORT/path`. You can pass a bare path for the URL.

This allows doing:

    0x --on-port 'autocannon /path' -- node server.js

When an invalid URL is given, autocannon now logs an error and exits.
(`/path` without a `$PORT` is an invalid URL.)

It uses the URL API which was backported to Node 6.13.0, if lower
versions of Node 6 should be supported I can change it to use
`url.parse` and `url.format` instead.