### PR TITLE
Fix throughput stats

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ function run (opts, cb) {
     autoResize: true,
     lowestDiscernibleValue: 1,
     highestTrackableValue: 100000000000,
-    numberOfSignificantValueDigits: 1
+    numberOfSignificantValueDigits: 3
   })
 
   const statusCodes = [


### PR DESCRIPTION
1 significant digit seems too low, this makes only first digit relevant. 
3 seems a good balance between precision and memory footprint

