### PR TITLE
Removed xtend and shallow-clone dependencies

### DIFF
--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const xtend = require('xtend')
 const methods = require('./httpMethods')
 const ending = Buffer.from('\r\n')
 
@@ -18,7 +17,7 @@ function requestBuilder (defaults) {
     port: 80
   }
 
-  defaults = xtend(builderDefaults, defaults)
+  defaults = Object.assign(builderDefaults, defaults)
 
   // buildRequest takes an object, and turns it into a buffer representing the
   // http request
@@ -26,9 +25,9 @@ function requestBuilder (defaults) {
     // below is a hack to enable deep extending of the headers so the default
     // headers object isn't overwritten by accident
     reqData = reqData || {}
-    reqData.headers = xtend(defaults.headers, reqData.headers)
+    reqData.headers = Object.assign({}, defaults.headers, reqData.headers)
 
-    reqData = xtend(defaults, reqData)
+    reqData = Object.assign({}, defaults, reqData)
     // for some reason some tests fail with method === undefined
     // the reqData.method should be set to SOMETHING in this case
     // cannot find reason for failure if `|| 'GET'` is taken out

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -6,7 +6,6 @@ const getBorderCharacters = require('table').getBorderCharacters
 const Chalk = require('chalk')
 const testColorSupport = require('color-support')
 const prettyBytes = require('pretty-bytes')
-const xtend = require('xtend')
 const format = require('./format')
 const percentiles = require('hdr-histogram-percentiles-obj').percentiles
 const defaults = {
@@ -22,7 +21,7 @@ function track (instance, opts) {
     throw new Error('instance required for tracking')
   }
 
-  opts = xtend(defaults, opts)
+  opts = Object.assign({}, defaults, opts)
 
   const chalk = new Chalk.constructor({ enabled: testColorSupport({ stream: opts.outputStream }) })
   // this default needs to be set after chalk is setup, because chalk is now local to this func

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,11 +3,9 @@
 const EE = require('events').EventEmitter
 const URL = require('url')
 const hdr = require('hdr-histogram-js')
-const clone = require('shallow-clone')
 const timestring = require('timestring')
 const Client = require('./httpClient')
 const DefaultOptions = require('./defaultOptions')
-const xtend = require('xtend')
 const histUtil = require('hdr-histogram-percentiles-obj')
 const reInterval = require('reinterval')
 const histAsObj = histUtil.histAsObj
@@ -52,7 +50,7 @@ function run (opts, cb) {
     0 // 5xx
   ]
 
-  opts = xtend(clone(DefaultOptions), opts)
+  opts = Object.assign({}, DefaultOptions, opts)
 
   // do error checking, if error, return
   if (checkOptsForErrors()) return

--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
     "progress": "^2.0.0",
     "reinterval": "^1.1.0",
     "retimer": "^1.0.1",
-    "shallow-clone": "^3.0.0",
     "table": "^5.1.0",
-    "timestring": "^5.0.1",
-    "xtend": "^4.0.1"
+    "timestring": "^5.0.1"
   }
 }

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -3,7 +3,6 @@
 const os = require('os')
 const path = require('path')
 const test = require('tap').test
-const clone = require('shallow-clone')
 const run = require('../lib/run')
 const defaultOptions = require('../lib/defaultOptions')
 const helper = require('./helper')
@@ -330,7 +329,7 @@ for (let i = 1; i <= 5; i++) {
 }
 
 test('run should not modify default options', (t) => {
-  const origin = clone(defaultOptions)
+  const origin = Object.assign({}, defaultOptions)
   run({
     url: 'http://localhost:' + server.address().port,
     connections: 2,


### PR DESCRIPTION
Hi,
I have implemented #169 and I have removed also the `shallow-clone` dependency because was used only to clone objects and also that implementation was with `Object.assign`.

Hope this help
Regards