### PR TITLE
Check to prevent infinite loop when amount is greater than connections

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -187,6 +187,9 @@ function run (opts, cb) {
       }
       if (amount) {
         url.responseMax = distributeNums(amount, i)
+        if (url.responseMax === 0) {
+          throw Error('connections cannot be greater than amount')
+        }
       }
       if (!opts.connectionRate && opts.overallRate) {
         url.rate = distributeNums(opts.overallRate, i)

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -426,3 +426,18 @@ test('tracker will emit reqError with error message on error', (t) => {
     tracker.stop()
   })
 })
+
+test('throw if connections is greater than amount', (t) => {
+  t.plan(1)
+
+  const server = helper.startSocketDestroyingServer()
+
+  t.throws(function () {
+    run({
+      url: `http://localhost:${server.address().port}`,
+      connections: 10,
+      amount: 1,
+      excludeErrorStats: true
+    })
+  })
+})


### PR DESCRIPTION
First time submitting a PR ever. I tried adding to checkOptsForErrors() function, but that just resulted in about 70 failed tests, adding the throw was **a lot** easier.