### PR TITLE
Avoid maxListenersExceededWarning on process when using the tracker API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ node_modules
 profile-*
 
 .nyc_output
+
+package-lock.json

--- a/autocannon.js
+++ b/autocannon.js
@@ -216,8 +216,10 @@ function createChannel (onport) {
 
 function runTracker (argv, ondone) {
   const tracker = run(argv)
+  function onSigInt () { tracker.stop() }
 
   tracker.on('done', (result) => {
+    process.removeListener(onSigInt)
     if (ondone) ondone()
     if (argv.json) {
       console.log(JSON.stringify(result))
@@ -226,6 +228,7 @@ function runTracker (argv, ondone) {
 
   tracker.on('error', (err) => {
     if (err) {
+      process.removeListener(onSigInt)
       throw err
     }
   })
@@ -233,9 +236,7 @@ function runTracker (argv, ondone) {
   // if not rendering json, or if std isn't a tty, track progress
   if (!argv.json || !process.stdout.isTTY) track(tracker, argv)
 
-  process.once('SIGINT', () => {
-    tracker.stop()
-  })
+  process.once('SIGINT', onSigInt)
 }
 
 if (require.main === module) {

--- a/autocannon.js
+++ b/autocannon.js
@@ -219,7 +219,7 @@ function runTracker (argv, ondone) {
   function onSigInt () { tracker.stop() }
 
   tracker.on('done', (result) => {
-    process.removeListener(onSigInt)
+    process.removeListener('SIGINT', onSigInt)
     if (ondone) ondone()
     if (argv.json) {
       console.log(JSON.stringify(result))
@@ -228,7 +228,7 @@ function runTracker (argv, ondone) {
 
   tracker.on('error', (err) => {
     if (err) {
-      process.removeListener(onSigInt)
+      process.removeListener('SIGINT', onSigInt)
       throw err
     }
   })

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -1,5 +1,4 @@
 'use strict'
-
 const ProgressBar = require('progress')
 const Table = require('cli-table3')
 const Chalk = require('chalk')
@@ -81,7 +80,6 @@ function track (instance, opts) {
           process.removeListener('SIGINT', completeDurationProgress)
         })
         process.once('SIGINT', completeDurationProgress)
-        console.log(process._events['SIGINT'])
       } else { // amount progress bar
         instance.on('response', () => { amountProgressBar.tick() })
         instance.on('reqError', () => { amountProgressBar.tick() })
@@ -90,7 +88,6 @@ function track (instance, opts) {
           process.removeListener('SIGINT', completeAmountProgress)
         })
         process.once('SIGINT', completeAmountProgress)
-        console.log(process._events['SIGINT'])
       }
     }
   }

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -62,32 +62,32 @@ function track (instance, opts) {
 
     addedListeners = true
 
-    function completeDurationProgress () {
-      durationProgressBar.tick(iOpts.duration - 1)
-    }
-
-    function completeAmountProgress () {
-      amountProgressBar.tick(iOpts.amount - 1)
+    function cancel () {
+      if (iOpts.amount) {
+        amountProgressBar.tick(iOpts.amount - 1)
+      } else {
+        durationProgressBar.tick(iOpts.duration - 1)
+      }
+      instance.cancel()
     }
 
     // note: Attempted to curry the functions below, but that breaks the functionality
     // as they use the scope/closure of the progress bar variables to allow them to be reset
     if (opts.outputStream.isTTY) {
+      process.once('SIGINT', cancel)
+      instance.on('done', () => process.removeListener('SIGINT', cancel))
+
       if (!iOpts.amount) { // duration progress bar
         instance.on('tick', () => { durationProgressBar.tick() })
         instance.on('done', () => {
           durationProgressBar.tick(iOpts.duration - 1)
-          process.removeListener('SIGINT', completeDurationProgress)
         })
-        process.once('SIGINT', completeDurationProgress)
       } else { // amount progress bar
         instance.on('response', () => { amountProgressBar.tick() })
         instance.on('reqError', () => { amountProgressBar.tick() })
         instance.on('done', () => {
           amountProgressBar.tick(iOpts.amount - 1)
-          process.removeListener('SIGINT', completeAmountProgress)
         })
-        process.once('SIGINT', completeAmountProgress)
       }
     }
   }

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -63,18 +63,34 @@ function track (instance, opts) {
 
     addedListeners = true
 
+    function completeDurationProgress () {
+      durationProgressBar.tick(iOpts.duration - 1)
+    }
+
+    function completeAmountProgress () {
+      amountProgressBar.tick(iOpts.amount - 1)
+    }
+
     // note: Attempted to curry the functions below, but that breaks the functionality
     // as they use the scope/closure of the progress bar variables to allow them to be reset
     if (opts.outputStream.isTTY) {
       if (!iOpts.amount) { // duration progress bar
         instance.on('tick', () => { durationProgressBar.tick() })
-        instance.on('done', () => { durationProgressBar.tick(iOpts.duration - 1) })
-        process.once('SIGINT', () => { durationProgressBar.tick(iOpts.duration - 1) })
+        instance.on('done', () => {
+          durationProgressBar.tick(iOpts.duration - 1)
+          process.removeListener('SIGINT', completeDurationProgress)
+        })
+        process.once('SIGINT', completeDurationProgress)
+        console.log(process._events['SIGINT'])
       } else { // amount progress bar
         instance.on('response', () => { amountProgressBar.tick() })
         instance.on('reqError', () => { amountProgressBar.tick() })
-        instance.on('done', () => { amountProgressBar.tick(iOpts.amount - 1) })
-        process.once('SIGINT', () => { amountProgressBar.tick(iOpts.amount - 1) })
+        instance.on('done', () => {
+          amountProgressBar.tick(iOpts.amount - 1)
+          process.removeListener('SIGINT', completeAmountProgress)
+        })
+        process.once('SIGINT', completeAmountProgress)
+        console.log(process._events['SIGINT'])
       }
     }
   }

--- a/lib/run.js
+++ b/lib/run.js
@@ -31,6 +31,10 @@ function _run (opts, cb, tracker) {
     })
     tracker.then = promise.then.bind(promise)
     tracker.catch = promise.catch.bind(promise)
+    tracker.cancel = function cancel () {
+      tracker.stop()
+      tracker.emit('canceled')
+    }
     return tracker
   }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const os = require('os')
 const http = require('http')
 const https = require('https')
 const tls = require('tls')
@@ -132,7 +133,8 @@ function startTlsServer () {
 }
 
 function mockTTY () {
-  const mock = fs.createWriteStream('/dev/null')
+  const tempFile = path.join(os.tmpdir(), `autocannon-mock-tty-${Date.now()}`)
+  const mock = fs.createWriteStream(tempFile)
   mock.isTTY = true
   mock.columns = 10
   mock.rows = 10

--- a/test/helper.js
+++ b/test/helper.js
@@ -131,11 +131,23 @@ function startTlsServer () {
   return server
 }
 
+function mockTTY () {
+  const mock = fs.createWriteStream('/dev/null')
+  mock.isTTY = true
+  mock.columns = 10
+  mock.rows = 10
+  mock.cursorTo = () => {}
+  mock.clearLine = () => {}
+
+  return mock
+}
+
 module.exports.startServer = startServer
 module.exports.startTimeoutServer = startTimeoutServer
 module.exports.startSocketDestroyingServer = startSocketDestroyingServer
 module.exports.startHttpsServer = startHttpsServer
 module.exports.startTrailerServer = startTrailerServer
 module.exports.startTlsServer = startTlsServer
+module.exports.mockTTY = mockTTY
 
 function noop () {}

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -441,7 +441,6 @@ test('tracker should not leak process SIGINT listeners', (t) => {
     title: 'title321'
   })
 
-  process.stderr.isTTY = true
   track(instance, { renderResultsTable: false, outputStream: helper.mockTTY() })
 
   instance.once('tick', () => {

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -443,12 +443,15 @@ test('tracker should not leak process SIGINT listeners', (t) => {
 
   track(instance, { renderResultsTable: false, outputStream: helper.mockTTY() })
 
-  instance.once('tick', () => {
+  instance.once('start', () => {
     t.equal(process._events['SIGINT'].length, defaultSigIntListeners + 1, `There should be ${defaultSigIntListeners + 1} SIGINT listeners while the benchmark is in progress. Found: ${process._events['SIGINT'].length}`)
   })
 
-  instance.then(result => {
-    t.equal(process._events['SIGINT'].length, defaultSigIntListeners, `There should be ${defaultSigIntListeners} SIGINT listeners at the end. Found: ${process._events['SIGINT'].length}`)
+  instance.once('done', () => {
+    // makes sure that all the other done listeners have been executed before checking
+    setImmediate(() => {
+      t.equal(process._events['SIGINT'].length, defaultSigIntListeners, `There should be ${defaultSigIntListeners} SIGINT listeners at the end. Found: ${process._events['SIGINT'].length}`)
+    })
   })
 })
 


### PR DESCRIPTION
This PR introduces a small change on the Tracker internals to make sure that the process on SIGINT event listener is cleaned up when the tracker is finished.

This can happen, for instance, when running multiple instances of autocannon in sequence to benchmark different variations of a given webserver.

The actual warning I got looks like this:

```
(node:39800) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```

## TODO

 - [ ] Add more coverage to new changes
 - [x] Make tests windows compatible (currently failing with `C:\dev\null does not exist`)
 - [ ] single listener to SIGINT in the runTracker
 - [ ] add a method in the progress tracker that we’d call to during SIGINT