### PR TITLE
TypeError: Cannot set property 'startTime' of undefined

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -42,13 +42,13 @@ function Client (opts) {
   // used for forcing reconnects
   this.reconnectRate = this.opts.reconnectRate
 
-  this.resData = []
+  this.resData = new Array(this.opts.pipelining)
   for (let i = 0; i < this.opts.pipelining; i++) {
-    this.resData.push({
+    this.resData[i] = {
       bytes: 0,
       headers: {},
       startTime: [0, 0]
-    })
+    }
   }
 
   // cer = current expected response

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -42,13 +42,13 @@ function Client (opts) {
   // used for forcing reconnects
   this.reconnectRate = this.opts.reconnectRate
 
-  this.resData = new Array(this.opts.pipelining)
-  for (let i = 0; i < this.resData.length; i++) {
-    this.resData[i] = {
+  this.resData = []
+  for (let i = 0; i < this.opts.pipelining; i++) {
+    this.resData.push({
       bytes: 0,
       headers: {},
       startTime: [0, 0]
-    }
+    })
   }
 
   // cer = current expected response

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -412,6 +412,18 @@ test('client should throw when attempting to modify the request with a pipelinin
   client.destroy()
 })
 
+test('client resData length should equal pipelining when greater than 1', (t) => {
+  t.plan(1)
+
+  const opts = server.address()
+  opts.pipelining = 10
+  const client = new Client(opts)
+
+  t.equal(client.resData.length, client.opts.pipelining)
+
+  client.destroy()
+})
+
 test('client should emit a timeout when no response is received', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
I received the following error for `opts.pipelining` value > 1.
`this.resData.length` always returned 1 for me.
[length source](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-properties-of-array-instances-length)

```
TypeError: Cannot set property 'startTime' of undefined
    at Client._doRequest (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/httpClient.js:146:33)
    at Client._connect (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/httpClient.js:135:10)
    at new Client (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/httpClient.js:100:8)
    at initialiseClients (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/run.js:214:20)
    at _run (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/run.js:114:3)
    at run (/Users/testing/Documents/Github/benchmark/node_modules/autocannon/lib/run.js:15:10)
    at Promise (/Users/testing/Documents/Github/benchmark/lib/autocannon.js:16:20)
```

This is my first PR, let me know if more is needed. 