### PR TITLE
add option to print errors

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -29,7 +29,7 @@ module.exports.parseArguments = parseArguments
 
 function parseArguments (argvs) {
   const argv = minimist(argvs, {
-    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort'],
+    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug'],
     alias: {
       connections: 'c',
       pipelining: 'p',
@@ -71,7 +71,8 @@ function parseArguments (argvs) {
       forever: false,
       method: 'GET',
       idReplacement: false,
-      excludeErrorStats: false
+      excludeErrorStats: false,
+      debug: false
     },
     '--': true
   })

--- a/help.txt
+++ b/help.txt
@@ -61,6 +61,8 @@ Available options:
         Server name for the SNI (Server Name Indication) TLS extension.
   -x/--excludeErrorStats
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
+  --debug
+        Print connection errors to stderr.
   -v/--version
         Print the version number.
   -h/--help

--- a/lib/run.js
+++ b/lib/run.js
@@ -241,6 +241,7 @@ function _run (opts, cb, tracker) {
     function onError (error) {
       for (let i = 0; i < opts.pipelining; i++) tracker.emit('reqError', error)
       errors++
+      if (opts.debug) console.error(error)
       if (opts.bailout && errors >= opts.bailout) stop = true
     }
 

--- a/test/debug.test.js
+++ b/test/debug.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const test = require('tap').test
+const Autocannon = require('../autocannon')
+
+test('debug works', (t) => {
+  t.plan(5)
+
+  var args = Autocannon.parseArguments([
+    '-H', 'X-Http-Method-Override=GET',
+    '-m', 'POST',
+    '-b', 'the body',
+    '--debug',
+    'http://localhost/foo/bar'
+  ])
+
+  t.equal(args.url, 'http://localhost/foo/bar')
+  t.strictSame(args.headers, { 'X-Http-Method-Override': 'GET' })
+  t.equal(args.method, 'POST')
+  t.equal(args.body, 'the body')
+  t.equal(args.debug, true)
+})


### PR DESCRIPTION
This patch adds ` --debug` flag that prints connection errors to `stderr`.

I've been messing around with HTTP parsers recently, and autocannon is a great way to test how well a server works. Being able to see errors are happening is usually a good indicator things are broken. And having a way to print out *what* those errors are is really convenient. So hence this patch.

Hope this is useful. Thanks!