### PR TITLE
fix host header being sent twice

### DIFF
--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -41,6 +41,10 @@ function requestBuilder (defaults) {
       const hostname = reqData.hostname
       const port = reqData.port
       host = hostname + ':' + port
+    } else if (reqData.headers.host) {
+      // host header is included in baseReq; remove it from the headers
+      // object so we don't send it a second time
+      delete reqData.headers.host
     }
 
     if (methods.indexOf(method) < 0) {


### PR DESCRIPTION
If the user specifies a custom host header, then the request will be sent with _two_ (identical) host headers. This is unnecessary, and breaks some systems (e.g., Google Kubernetes Engine fails to route inbound HTTP requests which include more than one host header).