### PR TITLE
Propagate counter on tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Checkout [this example](./samples/track-run.js) to see it in use, as well.
 Because an autocannon instance is an `EventEmitter`, it emits several events. these are below:
 
 * `start`: Emitted once everything has been setup in your autocannon instance and it has started. Useful for if running the instance forever.
-* `tick`: Emitted every second this autocannon is running a benchmark. Useful for displaying stats, etc. Used by the `track` function.
+* `tick`: Emitted every second this autocannon is running a benchmark. Useful for displaying stats, etc. Used by the `track` function. The `tick` event propagates the existing `counter` and `bytes` values, which can be used for extended reports.
 * `done`: Emitted when the autocannon finishes a benchmark. passes the `results` as an argument to the callback.
 * `response`: Emitted when the autocannons http-client gets a http response from the server. This passes the following arguments to the callback:
     * `client`: The `http-client` itself. Can be used to modify the headers and body the client will send to the server. API below.

--- a/lib/run.js
+++ b/lib/run.js
@@ -134,7 +134,7 @@ function _run (opts, cb, tracker) {
     totalCompletedRequests += counter
     requests.recordValue(counter)
     throughput.recordValue(bytes)
-    tracker.emit('tick', counter)
+    tracker.emit('tick', { counter, bytes })
     counter = 0
     bytes = 0
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -134,9 +134,9 @@ function _run (opts, cb, tracker) {
     totalCompletedRequests += counter
     requests.recordValue(counter)
     throughput.recordValue(bytes)
+    tracker.emit('tick', counter)
     counter = 0
     bytes = 0
-    tracker.emit('tick')
 
     if (stop) {
       if (stopTimer) clearTimeout(stopTimer)

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -439,6 +439,23 @@ test('tracker will emit reqError with error message on error', (t) => {
   })
 })
 
+test('tracker will emit tick with current counter value', (t) => {
+  t.plan(1)
+
+  const server = helper.startSocketDestroyingServer()
+
+  const tracker = run({
+    url: `http://localhost:${server.address().port}`,
+    connections: 10,
+    duration: 10
+  })
+
+  tracker.once('tick', (counter) => {
+    t.type(counter, 'number')
+    tracker.stop()
+  })
+})
+
 test('throw if connections is greater than amount', (t) => {
   t.plan(1)
 

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -451,7 +451,7 @@ test('tracker will emit tick with current counter value', (t) => {
   })
 
   tracker.once('tick', (counter) => {
-    t.type(counter, 'number')
+    t.type(counter, 'object')
     tracker.stop()
   })
 })


### PR DESCRIPTION
This PR adds the necessary logic to propagate the `counter` on the `tick` event. The new adjustments are also covered by integration tests.