### PR TITLE
fix: parse argument with ":" in value header

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -138,11 +138,10 @@ function parseArguments (argvs) {
     }
 
     argv.headers = argv.headers.reduce((obj, header) => {
-      let index
-      if (
-        (index = header.indexOf(':')) > 0 ||
-        (index = header.indexOf('=')) > 0
-      ) {
+      const colonIndex = header.indexOf(':')
+      const equalIndex = header.indexOf('=')
+      const index = Math.min(colonIndex < 0 ? Infinity : colonIndex, equalIndex < 0 ? Infinity : equalIndex)
+      if (Number.isFinite(index) && index > 0) {
         obj[header.slice(0, index)] = header.slice(index + 1).trim()
         return obj
       } else throw new Error(`An HTTP header was not correctly formatted: ${header}`)

--- a/test/argumentParsing.test.js
+++ b/test/argumentParsing.test.js
@@ -123,3 +123,27 @@ test('parse argument with "=" in value header', (t) => {
     header1: 'foo=bar'
   })
 })
+
+test('parse argument with ":" in value header', (t) => {
+  t.plan(1)
+
+  var args = Autocannon.parseArguments([
+    '-H', 'header1=foo:bar',
+    'http://localhost/foo/bar'
+  ])
+
+  t.strictSame(args.headers, {
+    header1: 'foo:bar'
+  })
+})
+
+test('parse argument not correctly formatted header', (t) => {
+  t.plan(1)
+
+  t.throws(() => {
+    Autocannon.parseArguments([
+      '-H', 'header1',
+      'http://localhost/foo/bar'
+    ])
+  }, /An HTTP header was not correctly formatted/)
+})


### PR DESCRIPTION
As documented header parsing should support arguments like
`-H "Date=Wed Jan 01 2020 20:02:36 GMT+0800 (Hong Kong Time)"`.

Currently the header would be sent as
`Date=Wed Jan 01 2020 20: 02:36 GMT+0800 (Hong Kong Time)`.

Fixes: https://github.com/nodejs/node/issues/31023
