### PR TITLE
fix: multipart form handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ Available options:
 	Note: This option needs to be used with the '-H/--headers' option in some frameworks
   -F/--form FORM
         Upload a form (multipart/form-data). The form options can be a JSON string like
-        '{ "field_1": { "type": "text", "value": "a text value"}, "field_2": { "type": "file", "path": "path to the file" } }'
+        '{ "field 1": { "type": "text", "value": "a text value"}, "field 2": { "type": "file", "path": "path to the file" } }'
         or a path to a JSON file containing the form options.
+        When uploading a file the default filename value can be overridden by using the corresponding option:
+        '{ "field name": { "type": "file", "path": "path to the file", "options": { "filename": "myfilename" } } }'
+        Passing the filepath to the form can be done by using the corresponding option:
+        '{ "field name": { "type": "file", "path": "path to the file", "options": { "filepath": "/some/path/myfilename" } } }'
   -i/--input FILE
         The body of the request. See '-b/body' for more details.
   -H/--headers K=V

--- a/help.txt
+++ b/help.txt
@@ -29,8 +29,12 @@ Available options:
         The body of the request.
   -F/--form FORM
         Upload a form (multipart/form-data). The form options can be a JSON string like
-        '{ "field_1": { "type": "text", "value": "a text value"}, "field_2": { "type": "file", "path": "path to the file" } }'
+        '{ "field 1": { "type": "text", "value": "a text value"}, "field 2": { "type": "file", "path": "path to the file" } }'
         or a path to a JSON file containing the form options.
+        When uploading a file the default filename value can be overridden by using the corresponding option:
+        '{ "field name": { "type": "file", "path": "path to the file", "options": { "filename": "myfilename" } } }'
+        Passing the filepath to the form can be done by using the corresponding option:
+        '{ "field name": { "type": "file", "path": "path to the file", "options": { "filepath": "/some/path/myfilename" } } }'
   -i/--input FILE
         The body of the request.
   -H/--headers K=V

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { resolve } = require('path')
+const { resolve, basename } = require('path')
 const { readFileSync } = require('fs')
 const FormData = require('form-data')
 
@@ -29,8 +29,11 @@ module.exports = (options) => {
         if (!path) {
           throw new Error(`Missing key 'path' in form object for key '${key}'`)
         }
+        const opts = obj[key] && obj[key].options
         const buffer = readFileSync(path)
-        form.append(key, buffer)
+        form.append(key, buffer, Object.assign({}, {
+          filename: basename(path)
+        }, opts))
         break
       }
       case 'text': {


### PR DESCRIPTION
Fix Content-Disposition header writing by exposing `form-data` `.append()` method options
in the `options` key of the form object when the type is `file`.
This allows passing a custom `filename` or `filepath` for a file. By default the `filename`
is set to the file name passed in the `path` key.

See:
* https://github.com/form-data/form-data/tree/v2.5.1#alternative-submission-methods
* https://github.com/form-data/form-data/tree/v2.5.1#void-append-string-field-mixed-value--mixed-options-

Fix #240 

@mcollina  I don't know if this is clear enough. Maybe I should add some examples.