### PR TITLE
Add expectBody option and related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Available options:
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
   -E/--expectBody EXPECTED
         Ensure the body matches this value. If enabled, mismatches count towards bailout.
+        Enabling this option will slow down the load testing.
   -v/--version
         Print the version number.
   -h/--help

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Available options:
   -T/--title TITLE
         The title to place in the results for identification.
   -b/--body BODY
-        The body of the request. 
+        The body of the request.
 	Note: This option needs to be used with the '-H/--headers' option in some frameworks
   -F/--form FORM
         Upload a form (multipart/form-data). The form options can be a JSON string like
@@ -108,6 +108,8 @@ Available options:
         Server name for the SNI (Server Name Indication) TLS extension.
   -x/--excludeErrorStats
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
+  -E/--expectBody EXPECTED
+        Ensure the body matches this value. If enabled, mismatches count towards bailout.
   -v/--version
         Print the version number.
   -h/--help
@@ -242,6 +244,7 @@ Start autocannon against the given target.
     * `forever`: A `Boolean` which allows you to setup an instance of autocannon that restarts indefinitely after emiting results with the `done` event. Useful for efficiently restarting your instance. To stop running forever, you must cause a `SIGINT` or call the `.stop()` function on your instance. _OPTIONAL_ default: `false`
     * `servername`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: `undefined`.
     * `excludeErrorStats`: A `Boolean` which allows you to disable tracking non 2xx code responses in latency and bytes per second calculations. _OPTIONAL_ default: `false`.
+    * `expectBody`: A `String` representing the expected response body. Each request whose response body is not equal to `expectBody`is counted in `mismatches`. If enabled, mismatches count towards bailout. _OPTIONAL_  
 * `cb`: The callback which is called on completion of a benchmark. Takes the following params. _OPTIONAL_.
     * `err`: If there was an error encountered with the run.
     * `results`: The results of the run.
@@ -310,6 +313,7 @@ The results object emitted by `done` and passed to the `autocannon()` callback h
 * `duration`: The amount of time the test took, **in seconds**.
 * `errors`: The number of connection errors (including timeouts) that occurred.
 * `timeouts`: The number of connection timeouts that occurred.
+* `mismatches`: The number of requests with a mismatched body.
 * `start`: A Date object representing when the test started.
 * `finish`: A Date object representing when the test ended.
 * `connections`: The amount of connections used (value of `opts.connections`).

--- a/autocannon.js
+++ b/autocannon.js
@@ -58,6 +58,7 @@ function parseArguments (argvs) {
       idReplacement: 'I',
       socketPath: 'S',
       excludeErrorStats: 'x',
+      expectBody: 'E',
       help: 'h'
     },
     default: {

--- a/help.txt
+++ b/help.txt
@@ -69,6 +69,8 @@ Available options:
         Server name for the SNI (Server Name Indication) TLS extension.
   -x/--excludeErrorStats
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
+  -E/--expectBody EXPECTED
+        Ensure the body matches this value. If enabled, mismatches count towards bailout.
   --debug
         Print connection errors to stderr.
   -v/--version

--- a/help.txt
+++ b/help.txt
@@ -71,6 +71,7 @@ Available options:
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
   -E/--expectBody EXPECTED
         Ensure the body matches this value. If enabled, mismatches count towards bailout.
+        Enabling this option will slow down the load testing.
   --debug
         Print connection errors to stderr.
   -v/--version

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -19,6 +19,7 @@ function Client (opts) {
   this.opts.setupClient = this.opts.setupClient || noop
   this.opts.pipelining = this.opts.pipelining || 1
   this.opts.port = this.opts.port || 80
+  this.opts.expectBody = this.opts.expectBody || null
   this.timeout = (this.opts.timeout || 10) * 1000
   this.ipc = !!this.opts.socketPath
   this.secure = this.opts.protocol === 'https:'
@@ -85,8 +86,15 @@ function Client (opts) {
     this.resData[this.cer].headers = opts
   }
 
-  this.parser[HTTPParser.kOnBody] = (body) => {
+  this.parser[HTTPParser.kOnBody] = (body, start, len) => {
     this.emit('body', body)
+
+    if (this.opts.expectBody) {
+      const bodyString = '' + body.slice(start, start + len)
+      if (this.opts.expectBody !== bodyString) {
+        return this.emit('mismatch', bodyString)
+      }
+    }
   }
 
   this.parser[HTTPParser.kOnMessageComplete] = () => {

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -124,6 +124,9 @@ function track (instance, opts) {
     if (result.errors) {
       logToStream(`${format(result.errors)} errors (${format(result.timeouts)} timeouts)`)
     }
+    if (result.mismatches) {
+      logToStream(`${format(result.mismatches)} requests with mismatched body`)
+    }
   })
 
   function logToStream (msg) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -316,6 +316,11 @@ function _run (opts, cb, tracker) {
       return true
     }
 
+    if (opts.expectBody && opts.requests !== DefaultOptions.requests) {
+      errorCb(new Error('expectBody cannot be used in conjunction with requests'))
+      return true
+    }
+
     if (lessThanOneError(opts.connections, 'connections')) return true
     if (lessThanOneError(opts.pipelining, 'pipelining factor')) return true
     if (greaterThanZeroError(opts.timeout, 'timeout')) return true

--- a/lib/run.js
+++ b/lib/run.js
@@ -88,6 +88,7 @@ function _run (opts, cb, tracker) {
   let bytes = 0
   let errors = 0
   let timeouts = 0
+  let mismatches = 0
   let totalBytes = 0
   let totalRequests = 0
   let totalCompletedRequests = 0
@@ -123,6 +124,7 @@ function _run (opts, cb, tracker) {
   url.idReplacement = opts.idReplacement
   url.socketPath = opts.socketPath
   url.servername = opts.servername
+  url.expectBody = opts.expectBody
 
   let clients = []
   initialiseClients(clients)
@@ -165,6 +167,7 @@ function _run (opts, cb, tracker) {
         throughput: addPercentiles(throughput, histAsObj(throughput, totalBytes)),
         errors: errors,
         timeouts: timeouts,
+        mismatches: mismatches,
         duration: Math.round((Date.now() - startTime) / 10) / 100,
         start: new Date(startTime),
         finish: new Date(),
@@ -190,6 +193,7 @@ function _run (opts, cb, tracker) {
           }, opts.duration * 1000)
           errors = 0
           timeouts = 0
+          mismatches = 0
           totalBytes = 0
           totalRequests = 0
           totalCompletedRequests = 0
@@ -229,6 +233,7 @@ function _run (opts, cb, tracker) {
       const client = new Client(url)
       client.on('response', onResponse)
       client.on('connError', onError)
+      client.on('mismatch', onExpectMismatch)
       client.on('timeout', onTimeout)
       client.on('request', () => { totalRequests++ })
       client.on('done', onDone)
@@ -257,6 +262,15 @@ function _run (opts, cb, tracker) {
       errors++
       if (opts.debug) console.error(error)
       if (opts.bailout && errors >= opts.bailout) stop = true
+    }
+
+    function onExpectMismatch (bpdyStr) {
+      for (let i = 0; i < opts.pipelining; i++) {
+        tracker.emit('reqMismatch', bpdyStr)
+      }
+
+      mismatches++
+      if (opts.bailout && mismatches >= opts.bailout) stop = true
     }
 
     // treat a timeout as a special type of error

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,7 +20,7 @@ function startServer (opts) {
 
   function handle (req, res) {
     res.statusCode = statusCode
-    res.end('hello world')
+    res.end(opts.body || 'hello world')
   }
 
   server.unref()

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -60,7 +60,7 @@ test('run', (t) => {
     t.ok(result.finish, 'finish time exists')
 
     t.equal(result.errors, 0, 'no errors')
-    t.equal(result.mismatches, 0, 'no errors')
+    t.equal(result.mismatches, 0, 'no mismatches')
 
     t.equal(result['1xx'], 0, '1xx codes')
     t.equal(result['2xx'], result.requests.total, '2xx codes')
@@ -124,7 +124,7 @@ test('tracker.stop()', (t) => {
     t.ok(result.finish, 'finish time exists')
 
     t.equal(result.errors, 0, 'no errors')
-    t.equal(result.mismatches, 0, 'no errors')
+    t.equal(result.mismatches, 0, 'no mismatches')
 
     t.equal(result['1xx'], 0, '1xx codes')
     t.equal(result['2xx'], result.requests.total, '2xx codes')
@@ -226,6 +226,20 @@ test('run should callback with an error after a bailout', (t) => {
   }, function (err, result) {
     t.error(err)
     t.ok(result, 'results should not exist')
+    t.end()
+  })
+})
+
+test('run should callback with an error using expectBody and requests', (t) => {
+  t.plan(2)
+
+  run({
+    url: 'http://localhost:' + server.address().port,
+    requests: [{ body: 'something' }],
+    expectBody: 'hello'
+  }, function (err, result) {
+    t.ok(err, 'expectBody used with requests should cause an error')
+    t.notOk(result, 'results should not exist')
     t.end()
   })
 })


### PR DESCRIPTION
This is probably a niche need driven by my paranoia. However, for certain scenarios it adds peace of mind knowing that the server sent what I expected it to back to the client. While this isn't necessarily the place of a benchmarking tool, it is helpful to me to have this for stress testing sorts of purposes.

I understand if it doesn't fit. That being said it's mostly an unobtrusive addition. The only thing it really imposes is the addition of `mismatches` to the API results. I suppose I could have fenced that off so that it only shows in the results if the option is enabled. Let me know if that would be desirable and I can do that.