### PR TITLE
Support for http requests with chunked body [WIP]

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -31,6 +31,7 @@ function parseArguments (argvs) {
   const argv = minimist(argvs, {
     boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug'],
     alias: {
+      chunkSize: ['k', 'chunk'],
       connections: 'c',
       pipelining: 'p',
       timeout: 't',
@@ -62,6 +63,7 @@ function parseArguments (argvs) {
       help: 'h'
     },
     default: {
+      chunkSize: 0,
       connections: 10,
       timeout: 10,
       pipelining: 1,

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -3,6 +3,7 @@
 const defaultOptions = {
   headers: {},
   body: Buffer.alloc(0),
+  chunkSize: 0,
   method: 'GET',
   duration: 10,
   connections: 10,

--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -20,10 +20,16 @@ function requestBuilder (defaults) {
 
   defaults = Object.assign(builderDefaults, defaults)
 
+  // cache chunks to avoid reprocessing
+  const chunkBodyCache = {}
   const chunkBody = (body, size) => {
     if (size === 0) {
       return body
     }
+    if (chunkBodyCache[body]) {
+      return chunkBodyCache[body]
+    }
+
     const chunks = []
     let found = body.search(/\[<id>\]/g)
     found = found === -1 ? false : found
@@ -39,6 +45,7 @@ function requestBuilder (defaults) {
       chunks.push(body.substr(start, size))
       start = start + size
     }
+    chunkBodyCache[body] = chunks
     return chunks
   }
 
@@ -47,10 +54,11 @@ function requestBuilder (defaults) {
       return [Buffer.from(chunks)]
     }
     const body = []
-    for (const chunk in chunks) {
+    for (let i = 0; i < chunks.length; ++i) {
+      const chunk = chunks[i]
       if (typeof chunk === 'string') {
         body.push(Buffer.from(`${chunk.length}\r\n`))
-        body.push(Buffer.from(chunk.join('\r\n')))
+        body.push(Buffer.concat([Buffer.from(chunk), Buffer.from('\r\n')]))
       } else if (Buffer.isBuffer(chunk)) {
         body.push(Buffer.from(`${chunk.length}\r\n`))
         body.push(Buffer.concat([chunk, Buffer.from('\r\n')]))
@@ -58,6 +66,7 @@ function requestBuilder (defaults) {
         throw new Error('body item must be either a string or a buffer')
       }
     }
+    body.push(Buffer.from('0\r\n')) // End of request marker
     return body
   }
 
@@ -134,7 +143,8 @@ function requestBuilder (defaults) {
     let req = Buffer.from(baseReq.join('\r\n') + '\r\n\r\n', 'utf8')
 
     if (bodyBuf && bodyBuf.length > 0) {
-      req = Buffer.concat([req, ...bodyBuf])
+      bodyBuf.unshift(req)
+      req = Buffer.concat(bodyBuf)
     }
 
     return req

--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -13,11 +13,53 @@ function requestBuilder (defaults) {
     headers: {},
     body: Buffer.alloc(0),
     hostname: 'localhost',
+    chunkSize: 0,
     setupRequest: reqData => reqData,
     port: 80
   }
 
   defaults = Object.assign(builderDefaults, defaults)
+
+  const chunkBody = (body, size) => {
+    if (size === 0) {
+      return body
+    }
+    const chunks = []
+    let found = body.search(/\[<id>\]/g)
+    found = found === -1 ? false : found
+    let start = 0
+    while (start < body.length) {
+      if (found && (start + size) > found) {
+        chunks.push(body.substr(start, found - start))
+        chunks.push('[<id>]')
+        start = found + '[<id>]'.length
+        found = false
+        continue
+      }
+      chunks.push(body.substr(start, size))
+      start = start + size
+    }
+    return chunks
+  }
+
+  const makeChunkedBody = (chunks) => {
+    if (typeof chunks === 'string') {
+      return [Buffer.from(chunks)]
+    }
+    const body = []
+    for (const chunk in chunks) {
+      if (typeof chunk === 'string') {
+        body.push(Buffer.from(`${chunk.length}\r\n`))
+        body.push(Buffer.from(chunk.join('\r\n')))
+      } else if (Buffer.isBuffer(chunk)) {
+        body.push(Buffer.from(`${chunk.length}\r\n`))
+        body.push(Buffer.concat([chunk, Buffer.from('\r\n')]))
+      } else {
+        throw new Error('body item must be either a string or a buffer')
+      }
+    }
+    return body
+  }
 
   // buildRequest takes an object, and turns it into a buffer representing the
   // http request
@@ -38,6 +80,7 @@ function requestBuilder (defaults) {
     const path = reqData.path
     const headers = reqData.headers
     const body = reqData.body
+    const chunkSize = reqData.chunkSize
 
     let host = reqData.headers.host || reqData.host
     if (!host) {
@@ -64,18 +107,24 @@ function requestBuilder (defaults) {
     let bodyBuf
 
     if (typeof body === 'string') {
-      bodyBuf = Buffer.from(body)
+      bodyBuf = makeChunkedBody(chunkBody(body, chunkSize))
     } else if (Buffer.isBuffer(body)) {
-      bodyBuf = body
+      bodyBuf = [body]
+    } else if (Array.isArray(body)) {
+      bodyBuf = makeChunkedBody(body)
     } else if (body) {
-      throw new Error('body must be either a string or a buffer')
+      throw new Error('body must be either a string or a buffer or an array')
     }
 
     if (bodyBuf && bodyBuf.length > 0) {
-      const idCount = reqData.idReplacement
-        ? (bodyBuf.toString().match(/\[<id>\]/g) || []).length
-        : 0
-      headers['Content-Length'] = `${bodyBuf.length + (idCount * 27)}`
+      if (bodyBuf.length > 1) {
+        headers['Transfer-Encoding'] = 'chunked'
+      } else if (bodyBuf[0].length > 0) {
+        const idCount = reqData.idReplacement
+          ? (bodyBuf[0].toString().match(/\[<id>\]/g) || []).length
+          : 0
+        headers['Content-Length'] = `${bodyBuf[0].length + (idCount * 27)}`
+      }
     }
 
     for (const [key, header] of Object.entries(headers)) {
@@ -85,7 +134,7 @@ function requestBuilder (defaults) {
     let req = Buffer.from(baseReq.join('\r\n') + '\r\n\r\n', 'utf8')
 
     if (bodyBuf && bodyBuf.length > 0) {
-      req = Buffer.concat([req, bodyBuf])
+      req = Buffer.concat([req, ...bodyBuf])
     }
 
     return req

--- a/lib/run.js
+++ b/lib/run.js
@@ -125,6 +125,7 @@ function _run (opts, cb, tracker) {
   url.socketPath = opts.socketPath
   url.servername = opts.servername
   url.expectBody = opts.expectBody
+  url.chunkSize = opts.chunkSize || 0
 
   let clients = []
   initialiseClients(clients)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "standard && tap --no-esm --no-jsx --timeout 45 test/serial/*.test.js test/*.test.js",
-    "standard:fix": "standard --fix"
+    "standard:fix": "standard --fix",
+    "utest": "tap --no-esm --no-jsx --timeout 45 test/httpRequestBuilder.test.js"
   },
   "pre-commit": [
     "test"

--- a/test/httpRequestBuilder.test.js
+++ b/test/httpRequestBuilder.test.js
@@ -144,7 +144,7 @@ test('request builder should allow http basic authentication', (t) => {
     'request is okay')
 })
 
-test('should throw error if body is not a string or a buffer', (t) => {
+test('should throw error if body is not a string or a buffer or an array', (t) => {
   t.plan(1)
 
   const opts = server.address()
@@ -152,8 +152,8 @@ test('should throw error if body is not a string or a buffer', (t) => {
   const build = RequestBuilder(opts)
 
   try {
-    build({ body: [] })
+    build({ body: 1 })
   } catch (error) {
-    t.is(error.message, 'body must be either a string or a buffer')
+    t.is(error.message, 'body must be either a string or a buffer or an array')
   }
 })


### PR DESCRIPTION
Issue: https://github.com/mcollina/autocannon/issues/256
To: @mcollina @yoshuawuyts 

This is pull request is a WIP to add a chunked body HTTP request feature.
Currently, only the `lib/httpRequestBuilder.js`  has been modified to present the change and bootstrap discussion around the expected API.

In the current implementation, user is expected to pass `chunkSize` in the as option to the requestData. by default chunkSize is zero and represents the number of chars used to split the request body. That is if chunkSize is zero, the request is just a normal one. if the chunkSize is greater that zero the body string is split and converted to an array of buffer according to [HTTP spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding).
The other way of passing chunk to the query builder is to specify the body as an array of string or buffer.

Currently, only minimal work is done to start a discussion around the API. Once the API is agreed implementation should be updated or enhanced along with integration with the CLI args and tests should be written.

```js
const instance = autocannon({
  url: 'http://localhost:3000'
  chunkeSize: 5,
  body: 'the quick brown fox [<id>] jumps over the lazy dog.'
}, console.log)
```

```js
const instance = autocannon({
  url: 'http://localhost:3000'
  body: [ 'the quick brown ', 'fox [<id>] jumps ', 'over the lazy dog.']
}, console.log)
```
  