### PR TITLE
Add a new feature to support run with multiple url

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -9,6 +9,7 @@ const DefaultOptions = require('./defaultOptions')
 const multipart = require('./multipart')
 const histUtil = require('hdr-histogram-percentiles-obj')
 const reInterval = require('reinterval')
+const { ofURL, checkURL } = require('./url')
 const histAsObj = histUtil.histAsObj
 const addPercentiles = histUtil.addPercentiles
 
@@ -79,9 +80,6 @@ function _run (opts, cb, tracker) {
   // is done
   tracker.opts = opts
 
-  if (opts.url.indexOf('http') !== 0) opts.url = 'http://' + opts.url
-  const url = URL.parse(opts.url) // eslint-disable-line node/no-deprecated-api
-
   if (opts.overallRate && (opts.overallRate < opts.connections)) opts.connections = opts.overallRate
 
   let counter = 0
@@ -109,22 +107,34 @@ function _run (opts, cb, tracker) {
     }
   }
 
-  // copy over fields so that the client
-  // performs the right HTTP requests
-  url.pipelining = opts.pipelining
-  url.method = opts.method
-  url.body = form ? form.getBuffer() : opts.body
-  url.headers = form ? Object.assign({}, opts.headers, form.getHeaders()) : opts.headers
-  url.setupClient = opts.setupClient
-  url.timeout = opts.timeout
-  url.requests = opts.requests
-  url.reconnectRate = opts.reconnectRate
-  url.responseMax = amount || opts.maxConnectionRequests || opts.maxOverallRequests
-  url.rate = opts.connectionRate || opts.overallRate
-  url.idReplacement = opts.idReplacement
-  url.socketPath = opts.socketPath
-  url.servername = opts.servername
-  url.expectBody = opts.expectBody
+  opts.url = ofURL(opts.url).map((url) => {
+    if (url.indexOf('http') !== 0) return 'http://' + url
+    return url
+  })
+
+  const urls = ofURL(opts.url, true).map(url => {
+    if (url.indexOf('http') !== 0) url = 'http://' + url
+    url = URL.parse(url) // eslint-disable-line node/no-deprecated-api
+
+    // copy over fields so that the client
+    // performs the right HTTP requests
+    url.pipelining = opts.pipelining
+    url.method = opts.method
+    url.body = form ? form.getBuffer() : opts.body
+    url.headers = form ? Object.assign({}, opts.headers, form.getHeaders()) : opts.headers
+    url.setupClient = opts.setupClient
+    url.timeout = opts.timeout
+    url.requests = opts.requests
+    url.reconnectRate = opts.reconnectRate
+    url.responseMax = amount || opts.maxConnectionRequests || opts.maxOverallRequests
+    url.rate = opts.connectionRate || opts.overallRate
+    url.idReplacement = opts.idReplacement
+    url.socketPath = opts.socketPath
+    url.servername = opts.servername
+    url.expectBody = opts.expectBody
+
+    return url
+  })
 
   let clients = []
   initialiseClients(clients)
@@ -217,6 +227,7 @@ function _run (opts, cb, tracker) {
 
   function initialiseClients (clients) {
     for (let i = 0; i < opts.connections; i++) {
+      const url = urls[i % urls.length]
       if (!amount && !opts.maxConnectionRequests && opts.maxOverallRequests) {
         url.responseMax = distributeNums(opts.maxOverallRequests, i)
       }
@@ -299,7 +310,7 @@ function _run (opts, cb, tracker) {
 
   // will return true if error with opts entered
   function checkOptsForErrors () {
-    if (!opts.url && !opts.socketPath) {
+    if (!checkURL(opts.url) && !opts.socketPath) {
       errorCb(new Error('url or socketPath option required'))
       return true
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/**
+ * check the url is not an empty string or empty array
+ * @param url
+ */
+function checkURL (url) {
+  return (typeof url === 'string' && url) ||
+    (Array.isArray(url) && url.length > 0)
+}
+
+/**
+ *
+ * @param url
+ * @param asArray
+ * @returns
+ */
+function ofURL (url, asArray) {
+  if (Array.isArray(url)) return url
+
+  if (typeof url === 'string') {
+    return {
+      map (fn) {
+        if (asArray) return [fn(url)]
+        return fn(url)
+      }
+    }
+  }
+
+  throw new Error('url should only be a string or an array of string')
+}
+
+exports.checkURL = checkURL
+exports.ofURL = ofURL

--- a/test/argumentParsing.test.js
+++ b/test/argumentParsing.test.js
@@ -147,3 +147,14 @@ test('parse argument not correctly formatted header', (t) => {
     ])
   }, /An HTTP header was not correctly formatted/)
 })
+
+test('parse argument with multiple url', (t) => {
+  t.plan(2)
+  var args = Autocannon.parseArguments([
+    'localhost/foo/bar',
+    'http://localhost/baz/qux'
+  ])
+
+  t.equal(args.url[0], 'http://localhost/foo/bar')
+  t.equal(args.url[1], 'http://localhost/baz/qux')
+})

--- a/test/runMultiServer.test.js
+++ b/test/runMultiServer.test.js
@@ -1,0 +1,40 @@
+const test = require('tap').test
+const run = require('../lib/run')
+const helper = require('./helper')
+
+const server1 = helper.startServer({ body: 'from server1' })
+const server2 = helper.startServer({ body: 'from server2' })
+const server3 = helper.startServer({ body: 'from server3' })
+
+test('should receive the message from different server', (t) => {
+  t.plan(3)
+
+  const instance = run({
+    url: [
+      server1,
+      server2,
+      server3
+    ].map(server => `http://localhost:${server.address().port}`),
+    duration: 1,
+    connections: 3
+  })
+
+  let receivedServer1 = false
+  let receivedServer2 = false
+  let receivedServer3 = false
+
+  instance.on('response', (client) => {
+    if (!receivedServer1 && client.parser.chunk.toString().includes('from server1')) {
+      receivedServer1 = true
+      t.pass()
+    }
+    if (!receivedServer2 && client.parser.chunk.toString().includes('from server2')) {
+      receivedServer2 = true
+      t.pass()
+    }
+    if (!receivedServer3 && client.parser.chunk.toString().includes('from server3')) {
+      receivedServer3 = true
+      t.pass()
+    }
+  })
+})


### PR DESCRIPTION
This is a non-breaking-change feature

## Why we need this feature

When we bench a distributed system across continents (such as a blockchain system), there is often no load balancing. At this time, if it supports natively multi-node bench, it will be very convenient.

## How to use it

Added a compatible new feature to support multiple URLs like this

```
autocannon http://localhost:1234 http://localhost:1235
```

also programmatically supported with

```js
const autocannon = require('autocannon')

autocannon({
    url: ['http://foo.bar:3000', 'http://baz.qux:3001']
})
```
