### PR TITLE
feat: Reponse handling and request context

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -86,29 +86,43 @@ function Client (opts) {
     this.resData[this.cer].headers = opts
   }
 
+  const emitAndMove = () => {
+    const resp = this.resData[this.cer]
+    this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration)
+    resp.bytes = 0
+    this.cer = this.cer === opts.pipelining - 1 ? 0 : this.cer++
+    this.requestIterator.nextRequest()
+    this._doRequest(this.cer)
+  }
+
   this.parser[HTTPParser.kOnBody] = (body, start, len) => {
     this.emit('body', body)
+    const bodyString = '' + body.slice(start, start + len)
 
     if (this.opts.expectBody) {
-      const bodyString = '' + body.slice(start, start + len)
       if (this.opts.expectBody !== bodyString) {
         return this.emit('mismatch', bodyString)
       }
+    }
+
+    const resp = this.resData[this.cer]
+    if (this.requestIterator.expectsBody()) {
+      this.requestIterator.recordBody(resp.headers.statusCode, bodyString)
+      emitAndMove()
     }
   }
 
   this.parser[HTTPParser.kOnMessageComplete] = () => {
     const end = process.hrtime(this.resData[this.cer].startTime)
-    const responseTime = end[0] * 1e3 + end[1] / 1e6
-    this.emit('response', this.resData[this.cer].headers.statusCode, this.resData[this.cer].bytes, responseTime)
-    this.resData[this.cer].bytes = 0
+    this.resData[this.cer].duration = end[0] * 1e3 + end[1] / 1e6
 
     if (!this.destroyed && this.reconnectRate && this.reqsMade % this.reconnectRate === 0) {
       return this._resetConnection()
     }
 
-    this.cer = this.cer === opts.pipelining - 1 ? 0 : this.cer++
-    this._doRequest(this.cer)
+    if (!this.requestIterator.expectsBody()) {
+      emitAndMove()
+    }
   }
 
   this._connect()
@@ -158,7 +172,7 @@ Client.prototype._doRequest = function (rpi) {
     }
     this.emit('request')
     this.resData[rpi].startTime = process.hrtime()
-    this.conn.write(this.requestIterator.move())
+    this.conn.write(this.getRequestBuffer())
     this.timeoutTicker.reschedule(this.timeout)
     this.reqsMade++
   } else {
@@ -188,7 +202,7 @@ Client.prototype.destroy = function () {
   }
 }
 
-Client.prototype.getRequestBuffer = function (newHeaders) {
+Client.prototype.getRequestBuffer = function () {
   return this.requestIterator.currentRequest.requestBuffer
 }
 

--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -20,8 +20,9 @@ function requestBuilder (defaults) {
   defaults = Object.assign(builderDefaults, defaults)
 
   // buildRequest takes an object, and turns it into a buffer representing the
-  // http request
-  return function buildRequest (reqData) {
+  // http request.
+  // second parameter is passed to setupRequest, when relevant
+  return function buildRequest (reqData, context) {
     // below is a hack to enable deep extending of the headers so the default
     // headers object isn't overwritten by accident
     reqData = reqData || {}
@@ -29,7 +30,7 @@ function requestBuilder (defaults) {
 
     reqData = Object.assign({}, defaults, reqData)
 
-    reqData = reqData.setupRequest(reqData)
+    reqData = reqData.setupRequest(reqData, context)
 
     // for some reason some tests fail with method === undefined
     // the reqData.method should be set to SOMETHING in this case

--- a/lib/requestIterator.js
+++ b/lib/requestIterator.js
@@ -9,6 +9,7 @@ function RequestIterator (opts) {
     return new RequestIterator(opts)
   }
 
+  this.context = {}
   this.reqDefaults = opts
   this.requestBuilder = requestBuilder(opts)
   this.setRequests(opts.requests)
@@ -19,7 +20,11 @@ inherits(RequestIterator, Object)
 RequestIterator.prototype.nextRequest = function () {
   ++this.currentRequestIndex
   this.currentRequestIndex = this.currentRequestIndex < this.requests.length ? this.currentRequestIndex : 0
+  if (this.currentRequestIndex === 0) {
+    this.context = {}
+  }
   this.currentRequest = this.requests[this.currentRequestIndex]
+  this.rebuildRequest()
   return this.currentRequest
 }
 
@@ -29,26 +34,11 @@ RequestIterator.prototype.nextRequestBuffer = function () {
   return this.currentRequest.requestBuffer
 }
 
-RequestIterator.prototype.move = function () {
-  // get the current buffer and proceed to next request
-  const ret = this.currentRequest.requestBuffer
-  this.nextRequest()
-  return this.reqDefaults.idReplacement
-    ? Buffer.from(ret.toString().replace(/\[<id>\]/g, hyperid()))
-    : ret
-}
-
 RequestIterator.prototype.setRequests = function (newRequests) {
   this.requests = newRequests || [{}]
   this.currentRequestIndex = 0
   this.currentRequest = this.requests[0]
-  this.rebuildRequests()
-}
-
-RequestIterator.prototype.rebuildRequests = function () {
-  this.requests.forEach((request) => {
-    request.requestBuffer = this.requestBuilder(request)
-  })
+  this.rebuildRequest()
 }
 
 RequestIterator.prototype.setHeaders = function (newHeaders) {
@@ -73,8 +63,22 @@ RequestIterator.prototype.setRequest = function (newRequest) {
 }
 
 RequestIterator.prototype.rebuildRequest = function () {
-  this.currentRequest.requestBuffer = this.requestBuilder(this.currentRequest)
-  this.requests[this.currentRequestIndex] = this.currentRequest
+  if (this.currentRequest) {
+    const data = this.requestBuilder(this.currentRequest, this.context)
+    this.currentRequest.requestBuffer = this.reqDefaults.idReplacement
+      ? Buffer.from(data.toString().replace(/\[<id>\]/g, hyperid()))
+      : data
+  }
+}
+
+RequestIterator.prototype.expectsBody = function () {
+  return this.currentRequest && typeof this.currentRequest.onResponse === 'function'
+}
+
+RequestIterator.prototype.recordBody = function (status, body) {
+  if (this.expectsBody()) {
+    this.currentRequest.onResponse(status, body, this.context)
+  }
 }
 
 module.exports = RequestIterator

--- a/samples/request-context.js
+++ b/samples/request-context.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const http = require('http')
+const autocannon = require('../')
+
+const server = http.createServer(handle)
+
+server.listen(0, startBench)
+
+function handle (req, res) {
+  const body = []
+  // this route handler simply returns whatever it gets from response
+  req
+    .on('data', chunk => body.push(chunk))
+    .on('end', () => res.end(Buffer.concat(body)))
+}
+
+function startBench () {
+  const url = 'http://localhost:' + server.address().port
+
+  autocannon({
+    url: url,
+    requests: [
+      {
+        // let's create a new user
+        method: 'POST',
+        path: '/users',
+        body: JSON.stringify({ firstName: 'Jane', id: 10 }),
+        onResponse: (status, body, context) => {
+          if (status === 200) {
+            context.user = JSON.parse(body)
+          } // on error, you may abort the benchmark
+        }
+      },
+      {
+        // now we'll give them a last name
+        method: 'PUT',
+        setupRequest: (req, context) => ({
+          ...req,
+          path: `/user/${context.user.id}`,
+          body: JSON.stringify({
+            ...context.user,
+            lastName: 'Doe'
+          })
+        })
+      }
+    ]
+  }, finishedBench)
+
+  function finishedBench (err, res) {
+    console.log('finished bench', err, res)
+  }
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,7 +20,7 @@ function startServer (opts) {
 
   function handle (req, res) {
     res.statusCode = statusCode
-    res.end(opts.body || 'hello world')
+    res.end(typeof opts.body === 'function' ? opts.body(req) : (opts.body || 'hello world'))
   }
 
   server.unref()


### PR DESCRIPTION
### What's in there?

We would like, when using autocannon's node API, to have more control over requests.
In particular, we need to get the response of the previous request, extract some data out of it, and use it for the next request.

#### The proposed approach

It is already possible to customize sent request with `setupRequest(req) { return req }` function.
The idea is:
 1. to add an extra parameter: a context object that would last until autocannon loops over available requests.
 2. to support an `onResponse(status, body, context) {}` function, that can massage server response and enrich context passed to the next request.

```js
  // from samples/request-context.js

  autocannon({
    url: url,
    requests: [
      {
        // let's create a new user
        method: 'POST',
        path: '/users',
        body: JSON.stringify({ firstName: 'Jane', id: 10 }),
        onResponse: (status, body, context) => {
          if (status === 200) {
            context.user = JSON.parse(body)
          } // on error, you may abort the benchmark
        }
      },
      {
        // now we'll give them a last name
        method: 'PUT',
        setupRequest: (req, context) => ({
          ...req,
          path: `/user/${context.user.id}`,
          body: JSON.stringify({
            ...context.user,
            lastName: 'Doe'
          })
        })
      }
    ]
  })
```

#### Why not using `response` event from autocannon?

This event is fired when autocannon received the response header. It does not have access to the body.

Besides, autocannon generates all request bodies once for all, before it enters the loop, which makes customization very difficult (we would need to use client's `setBody()` function.

#### Drawbacks of this approach

`setupRequest()` function is now called right before issuing request, instead of once for all, before starting benchmark.

These is a breaking change in autocannon's current behaviour. However, I'll argue it makes much sense, for such dynamic function, to behaves this way. 
I'm totally open to other approaches! Please challenge this one.

### Notes to reviewers

Because some request may care about their response, and some other won't, `HttpClient`will trigger next request accordingly.
- when current request has no `onResponse`: the `reponse` event is emitted when response headers are received, and next request is triggered (current behaviour)
- when current request has an `onResponse` function: the `response` event is emitted when the body is received, and the next request is triggered.

`RequestIterator` offers much more possibilities than `HttpClient`needs. Applying changes and keeping a consistent API was tricky: its API is both flexible and pervasive:
- `move()` was the only way to substitute id in the request buffer. But it was also moving to next request. 
- `setRequests()` was computing all request buffers at once.

For the reasons explained above, the new approach is simpler and more consistent:
1. `nextRequest()` is the only whay to move the iterator
1. `rebuildRequest()` is handling id substitution, ensuring that request buffer is always ready to be sent.

