### PR TITLE
feat: add a correct coordinated omission option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Available options:
         connection rate will take precedence if both are set.
         NOTE: if using rate limiting and a very large rate is entered which cannot be met,
               Autocannon will do as many requests as possible per second.
+  -C/--correctCoordinatedOmission
+        Correct coordinated omission issue. Can be used in conjunction with 'connectionRate' or 'overallRate'.
   -D/--reconnectRate NUM
         Some number of requests to make before resetting a connections connection to the
         server.
@@ -239,6 +241,7 @@ Start autocannon against the given target.
     * `maxOverallRequests`: A `Number` stating the max requests to make overall. Can't be less than `connections`. `maxConnectionRequests` takes precedence if both are set. _OPTIONAL_
     * `connectionRate`: A `Number` stating the rate of requests to make per second from each individual connection. No rate limiting by default. _OPTIONAL_
     * `overallRate`: A `Number` stating the rate of requests to make per second from all connections. `connectionRate` takes precedence if both are set. No rate limiting by default. _OPTIONAL_
+    * `correctCoordinatedOmission`: A `Boolean` which allows to correct coordinated omission issue. Can't work if no rate of requests has been specified (`connectionRate` or `overallRate`). _OPTIONAL_ default: `false`.
     * `reconnectRate`: A `Number` which makes the individual connections disconnect and reconnect to the server whenever it has sent that number of requests. _OPTIONAL_
     * `requests`: An `Array` of `Object`s which represents the sequence of requests to make while benchmarking. Can be used in conjunction with the `body`, `headers` and `method` params above. Check the samples folder for an example of how this might be used. _OPTIONAL_. Contained objects can have these attributes:
        * `body`: When present, will override `opts.body`. _OPTIONAL_.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Available options:
               Autocannon will do as many requests as possible per second. Also latency data will be corrected in order to compensate the effects of coordinated omission issue. If you are not familiar with the coordinated omission issue, you should probably read [this article](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) or watch this [Gil Tene's talk](https://www.youtube.com/watch?v=lJ8ydIuPFeU) on the topic.
   -C/--ignoreCoordinatedOmission
         Ignore coordinated omission issue when requests should be sent at a fixed rate using 'connectionRate' or 'overallRate'. 
-      NOTE: it is not recommanded to enable this option. When the request rate cannot be met because the server is too slow, many request latencies might be missing and Autocannon might report a misleading latency distribution.
+        NOTE: it is not recommanded to enable this option. 
+              When the request rate cannot be met because the server is too slow, many request latencies might be missing and Autocannon might report a misleading latency distribution.
   -D/--reconnectRate NUM
         Some number of requests to make before resetting a connections connection to the
         server.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ Available options:
         The max number of requests to make per second from an all connections.
         connection rate will take precedence if both are set.
         NOTE: if using rate limiting and a very large rate is entered which cannot be met,
-              Autocannon will do as many requests as possible per second.
-  -C/--correctCoordinatedOmission
-        Correct coordinated omission issue. Can be used in conjunction with 'connectionRate' or 'overallRate'.
+              Autocannon will do as many requests as possible per second. Also latency data will be corrected in order to compensate the effects of coordinated omission issue. If you are not familiar with the coordinated omission issue, you should probably read [this article](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) or watch this [Gil Tene's talk](https://www.youtube.com/watch?v=lJ8ydIuPFeU) on the topic.
+  -C/--ignoreCoordinatedOmission
+        Ignore coordinated omission issue when requests should be sent at a fixed rate using 'connectionRate' or 'overallRate'. 
+      NOTE: it is not recommanded to enable this option. When the request rate cannot be met because the server is too slow, many request latencies might be missing and Autocannon might report a misleading latency distribution.
   -D/--reconnectRate NUM
         Some number of requests to make before resetting a connections connection to the
         server.
@@ -241,7 +242,7 @@ Start autocannon against the given target.
     * `maxOverallRequests`: A `Number` stating the max requests to make overall. Can't be less than `connections`. `maxConnectionRequests` takes precedence if both are set. _OPTIONAL_
     * `connectionRate`: A `Number` stating the rate of requests to make per second from each individual connection. No rate limiting by default. _OPTIONAL_
     * `overallRate`: A `Number` stating the rate of requests to make per second from all connections. `connectionRate` takes precedence if both are set. No rate limiting by default. _OPTIONAL_
-    * `correctCoordinatedOmission`: A `Boolean` which allows to correct coordinated omission issue. Can't work if no rate of requests has been specified (`connectionRate` or `overallRate`). _OPTIONAL_ default: `false`.
+    * `ignoreCoordinatedOmission`: A `Boolean` which disable the correction of latencies to compensate the coordinated omission issue. Does not make sense when no rate of requests has been specified (`connectionRate` or `overallRate`). _OPTIONAL_ default: `false`.
     * `reconnectRate`: A `Number` which makes the individual connections disconnect and reconnect to the server whenever it has sent that number of requests. _OPTIONAL_
     * `requests`: An `Array` of `Object`s which represents the sequence of requests to make while benchmarking. Can be used in conjunction with the `body`, `headers` and `method` params above. Check the samples folder for an example of how this might be used. _OPTIONAL_. Contained objects can have these attributes:
        * `body`: When present, will override `opts.body`. _OPTIONAL_.

--- a/autocannon.js
+++ b/autocannon.js
@@ -30,7 +30,7 @@ module.exports.parseArguments = parseArguments
 
 function parseArguments (argvs) {
   const argv = minimist(argvs, {
-    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug'],
+    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'correctCoordinatedOmission'],
     alias: {
       connections: 'c',
       pipelining: 'p',
@@ -51,6 +51,7 @@ function parseArguments (argvs) {
       maxOverallRequests: 'O',
       connectionRate: 'r',
       overallRate: 'R',
+      correctCoordinatedOmission: 'C',
       reconnectRate: 'D',
       renderProgressBar: 'progress',
       title: 'T',

--- a/autocannon.js
+++ b/autocannon.js
@@ -30,7 +30,7 @@ module.exports.parseArguments = parseArguments
 
 function parseArguments (argvs) {
   const argv = minimist(argvs, {
-    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'correctCoordinatedOmission'],
+    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'ignoreCoordinatedOmission'],
     alias: {
       connections: 'c',
       pipelining: 'p',
@@ -51,7 +51,7 @@ function parseArguments (argvs) {
       maxOverallRequests: 'O',
       connectionRate: 'r',
       overallRate: 'R',
-      correctCoordinatedOmission: 'C',
+      ignoreCoordinatedOmission: 'C',
       reconnectRate: 'D',
       renderProgressBar: 'progress',
       title: 'T',

--- a/help.txt
+++ b/help.txt
@@ -51,7 +51,15 @@ Available options:
         The max number of requests to make per second from an all connections.
         connection rate will take precedence if both are set.
         NOTE: if using rate limiting and a very large rate is entered which cannot be met,
-              Autocannon will do as many requests as possible per second.
+              Autocannon will do as many requests as possible per second. Also latency data will be corrected in order to 
+              compensate the effects of coordinated omission issue. If you are not familiar with the coordinated omission 
+              issue, you should probably read [this article](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) 
+              or watch this [Gil Tene's talk](https://www.youtube.com/watch?v=lJ8ydIuPFeU) on the topic.
+  -C/--ignoreCoordinatedOmission
+        Ignore coordinated omission issue when requests should be sent at a fixed rate using 'connectionRate' or 'overallRate'. 
+        NOTE: it is not recommanded to enable this option. 
+              When the request rate cannot be met because the server is too slow, 
+              many request latencies might be missing and Autocannon might report a misleading latency distribution.
   -D/--reconnectRate NUM
         Some number of requests to make before resetting a connections connection to the
         server.

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -110,7 +110,7 @@ function Client (opts) {
       return this._resetConnection()
     }
 
-    this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration)
+    this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration, this.rate)
     resp.bytes = 0
     this.cer = this.cer === pipelining - 1 ? 0 : this.cer++
     this._doRequest(this.cer)

--- a/lib/run.js
+++ b/lib/run.js
@@ -262,9 +262,9 @@ function _run (opts, cb, tracker) {
       tracker.emit('response', this, statusCode, resBytes, responseTime)
       const codeIndex = Math.floor(parseInt(statusCode) / 100) - 1
       statusCodes[codeIndex] += 1
-      // only recordValue 2xx latenciesxz
+      // only recordValue 2xx latencies
       if (codeIndex === 1 || includeErrorStats) {
-        if (rate && opts.correctCoordinatedOmission) {
+        if (rate && !opts.ignoreCoordinatedOmission) {
           latencies.recordValueWithExpectedInterval(responseTime, Math.ceil(1 / rate))
         } else {
           latencies.recordValue(responseTime)
@@ -348,8 +348,8 @@ function _run (opts, cb, tracker) {
     if (opts.maxConnectionRequests && lessThanOneError(opts.maxConnectionRequests, 'maxConnectionRequests')) return true
     if (opts.maxOverallRequests && lessThanOneError(opts.maxOverallRequests, 'maxOverallRequests')) return true
 
-    if (opts.correctCoordinatedOmission && !opts.connectionRate && !opts.overallRate) {
-      errorCb(new Error('correctCoordinatedOmission should be used in conjunction of connectionRate or overallRate'))
+    if (opts.ignoreCoordinatedOmission && !opts.connectionRate && !opts.overallRate) {
+      errorCb(new Error('ignoreCoordinatedOmission makes no sense without connectionRate or overallRate'))
       return true
     }
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -185,6 +185,7 @@ function _run (opts, cb, tracker) {
         pipelining: opts.pipelining,
         non2xx: statusCodes[0] + statusCodes[2] + statusCodes[3] + statusCodes[4]
       }
+      result.latency.totalCount = latencies.totalCount
       result.requests.sent = totalRequests
       statusCodes.forEach((code, index) => { result[(index + 1) + 'xx'] = code })
       if (result.requests.min === Number.MAX_SAFE_INTEGER) result.requests.min = 0

--- a/lib/run.js
+++ b/lib/run.js
@@ -258,12 +258,18 @@ function _run (opts, cb, tracker) {
       return (Math.floor(x / opts.connections) + (((i + 1) <= (x % opts.connections)) ? 1 : 0))
     }
 
-    function onResponse (statusCode, resBytes, responseTime) {
+    function onResponse (statusCode, resBytes, responseTime, rate) {
       tracker.emit('response', this, statusCode, resBytes, responseTime)
       const codeIndex = Math.floor(parseInt(statusCode) / 100) - 1
       statusCodes[codeIndex] += 1
-      // only recordValue 2xx latencies
-      if (codeIndex === 1 || includeErrorStats) latencies.recordValue(responseTime)
+      // only recordValue 2xx latenciesxz
+      if (codeIndex === 1 || includeErrorStats) {
+        if (rate && opts.correctCoordinatedOmission) {
+          latencies.recordValueWithExpectedInterval(responseTime, Math.ceil(1 / rate))
+        } else {
+          latencies.recordValue(responseTime)
+        }
+      }
       if (codeIndex === 1 || includeErrorStats) bytes += resBytes
       counter++
     }
@@ -341,6 +347,11 @@ function _run (opts, cb, tracker) {
     if (opts.amount && lessThanOneError(opts.amount, 'amount')) return true
     if (opts.maxConnectionRequests && lessThanOneError(opts.maxConnectionRequests, 'maxConnectionRequests')) return true
     if (opts.maxOverallRequests && lessThanOneError(opts.maxOverallRequests, 'maxOverallRequests')) return true
+
+    if (opts.correctCoordinatedOmission && !opts.connectionRate && !opts.overallRate) {
+      errorCb(new Error('correctCoordinatedOmission should be used in conjunction of connectionRate or overallRate'))
+      return true
+    }
 
     if (opts.forever && cbPassedIn) {
       errorCb(new Error('should not use the callback parameter when the `forever` option is set to true. Use the `done` event on this event emitter'))

--- a/test/runRate.test.js
+++ b/test/runRate.test.js
@@ -41,3 +41,32 @@ test('run should only send the expected number of requests per second', (t) => {
     t.equal(res.requests.average, 10, 'should have sent 10 requests per second on average')
   })
 })
+
+test('run should compensate for coordinated omission when the expected number of requests per second is too high', (t) => {
+  t.plan(2)
+
+  run({
+    url: `http://localhost:${server.address().port}`,
+    connections: 100,
+    connectionRate: 1000,
+    duration: 1
+  }, (err, res) => {
+    t.error(err)
+    t.notEqual(res.latency.totalCount, res.requests.total, 'should have recorded additionnal latencies')
+  })
+})
+
+test('run should not compensate for coordinated omission when this feature is disabled', (t) => {
+  t.plan(2)
+
+  run({
+    url: `http://localhost:${server.address().port}`,
+    connections: 100,
+    connectionRate: 1000,
+    ignoreCoordinatedOmission: true,
+    duration: 1
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.latency.totalCount, res.requests.total, 'should not have recorded additionnal latencies')
+  })
+})


### PR DESCRIPTION
Hello!
This is a small PR to add a `correct coordinated omission` feature to autocannon. 
It works with either connectionRate or overallRate options. 
I have left it deactivated by default since the impact on the displayed latencies can be quite significant...
Let me know if you need me to do any change