### PR TITLE
Enable SNI servername by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Available options:
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
   -s/--servername
-        Server name for the SNI (Server Name Indication) TLS extension.
+        Server name for the SNI (Server Name Indication) TLS extension. Defaults to the hostname of the URL when it is not an IP address.
   -x/--excludeErrorStats
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
   -E/--expectBody EXPECTED
@@ -254,7 +254,7 @@ Start autocannon against the given target.
        * `onResponse`: A `Function` you may provide to process the received response. It takes `status` (Number), `body` (String) and `context` (Object) parameters. _OPTIONAL_.
     * `idReplacement`: A `Boolean` which enables the replacement of `[<id>]` tags within the request body with a randomly generated ID, allowing for unique fields to be sent with requests. Check out [an example of programmatic usage](./samples/using-id-replacement.js) can be found in the samples. _OPTIONAL_ default: `false`
     * `forever`: A `Boolean` which allows you to setup an instance of autocannon that restarts indefinitely after emiting results with the `done` event. Useful for efficiently restarting your instance. To stop running forever, you must cause a `SIGINT` or call the `.stop()` function on your instance. _OPTIONAL_ default: `false`
-    * `servername`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: `undefined`.
+    * `servername`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: Defaults to the hostname of the URL when it is not an IP address.
     * `excludeErrorStats`: A `Boolean` which allows you to disable tracking non 2xx code responses in latency and bytes per second calculations. _OPTIONAL_ default: `false`.
     * `expectBody`: A `String` representing the expected response body. Each request whose response body is not equal to `expectBody`is counted in `mismatches`. If enabled, mismatches count towards bailout. _OPTIONAL_  
 * `cb`: The callback which is called on completion of a benchmark. Takes the following params. _OPTIONAL_.

--- a/help.txt
+++ b/help.txt
@@ -74,7 +74,7 @@ Available options:
   -f/--forever
         Run the benchmark forever. Efficiently restarts the benchmark on completion. default: false.
   -s/--servername
-        Server name for the SNI (Server Name Indication) TLS extension.
+        Server name for the SNI (Server Name Indication) TLS extension. Defaults to the hostname of the URL when it is not an IP address.
   -x/--excludeErrorStats
         Exclude error statistics (non 2xx http responses) from the final latency and bytes per second averages. default: false.
   -E/--expectBody EXPECTED

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -124,7 +124,7 @@ inherits(Client, EE)
 Client.prototype._connect = function () {
   if (this.secure) {
     let servername
-    if (typeof this.opts.servername === 'string') {
+    if (this.opts.servername) {
       servername = this.opts.servername
     } else if (!net.isIP(this.opts.hostname)) {
       servername = this.opts.hostname

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -123,10 +123,17 @@ inherits(Client, EE)
 
 Client.prototype._connect = function () {
   if (this.secure) {
+    let servername
+    if (typeof this.opts.servername === 'string') {
+      servername = this.opts.servername
+    } else if (!net.isIP(this.opts.hostname)) {
+      servername = this.opts.hostname
+    }
+
     if (this.ipc) {
       this.conn = tls.connect(this.opts.socketPath, { rejectUnauthorized: false })
     } else {
-      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername: this.opts.servername })
+      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername })
     }
   } else {
     if (this.ipc) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -96,20 +96,11 @@ function startTlsServer () {
   const key = fs.readFileSync(path.join(__dirname, '/key.pem'))
   const cert = fs.readFileSync(path.join(__dirname, '/cert.pem'))
   const passphrase = 'test'
-  var servername = ''
 
   const options = {
     key,
     cert,
-    passphrase,
-    SNICallback: function (name, cb) {
-      servername = name
-      cb(null, tls.createSecureContext({
-        key,
-        cert,
-        passphrase
-      }))
-    }
+    passphrase
   }
 
   const server = tls.createServer(options, handle)
@@ -117,6 +108,7 @@ function startTlsServer () {
   server.listen(0)
 
   function handle (socket) {
+    const servername = socket.servername || ''
     socket.on('data', function (data) {
       // Assume this is a http get request and send back the servername in an otherwise empty reponse.
       socket.write('HTTP/1.1 200 OK\nX-servername: ' + servername + '\nContent-Length: 0\n\n')

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -151,6 +151,24 @@ test('client ignores IP address in hostname-derived SNI servername', (t) => {
   })
 })
 
+test('client ignores falsy SNI servername', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  opts.servername = ''
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', '', 'Content-Length', '0'])
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
 test('http client automatically reconnects', (t) => {
   t.plan(4)
 

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -96,6 +96,61 @@ test('client calls a tls server with SNI servername twice', (t) => {
   })
 })
 
+test('client uses SNI servername from URL hostname by default', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  opts.hostname = 'localhost'
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', opts.hostname, 'Content-Length', '0'])
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
+test('client prefers SNI servername from opts over URL hostname', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  opts.hostname = 'localhost'
+  opts.servername = 'example.com'
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', opts.servername, 'Content-Length', '0'])
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
+test('client ignores IP address in hostname-derived SNI servername', (t) => {
+  t.plan(4)
+
+  var opts = tlsServer.address()
+  opts.protocol = 'https:'
+  opts.hostname = opts.address
+  const client = new Client(opts)
+  let count = 0
+
+  client.on('headers', (response) => {
+    t.equal(response.statusCode, 200, 'status code matches')
+    t.deepEqual(response.headers, ['X-servername', '', 'Content-Length', '0'])
+    if (count++ > 0) {
+      client.destroy()
+    }
+  })
+})
+
 test('http client automatically reconnects', (t) => {
   t.plan(4)
 


### PR DESCRIPTION
Default to sending the SNI servername when the `servername` option is not present or falsy. This behaviour matches browsers as well as popular tools like `curl` or `openssl s_client`.

Fixes: https://github.com/mcollina/autocannon/issues/233