### PR TITLE
Enable WASM for HdrHistogramJS

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -36,7 +36,10 @@ function _run (opts, cb, tracker) {
     return tracker
   }
 
+  hdr.initWebAssemblySync()
+
   const latencies = hdr.build({
+    useWebAssembly: true,
     bitBucketSize: 64,
     autoResize: true,
     lowestDiscernibleValue: 1,
@@ -45,6 +48,7 @@ function _run (opts, cb, tracker) {
   })
 
   const requests = hdr.build({
+    useWebAssembly: true,
     bitBucketSize: 64,
     autoResize: true,
     lowestDiscernibleValue: 1,
@@ -53,6 +57,7 @@ function _run (opts, cb, tracker) {
   })
 
   const throughput = hdr.build({
+    useWebAssembly: true,
     bitBucketSize: 64,
     autoResize: true,
     lowestDiscernibleValue: 1,
@@ -188,12 +193,17 @@ function _run (opts, cb, tracker) {
       result.latency.totalCount = latencies.totalCount
       result.requests.sent = totalRequests
       statusCodes.forEach((code, index) => { result[(index + 1) + 'xx'] = code })
-      if (result.requests.min === Number.MAX_SAFE_INTEGER) result.requests.min = 0
-      if (result.throughput.min === Number.MAX_SAFE_INTEGER) result.throughput.min = 0
-      if (result.latency.min === Number.MAX_SAFE_INTEGER) result.latency.min = 0
+      if (result.requests.min >= Number.MAX_SAFE_INTEGER) result.requests.min = 0
+      if (result.throughput.min >= Number.MAX_SAFE_INTEGER) result.throughput.min = 0
+      if (result.latency.min >= Number.MAX_SAFE_INTEGER) result.latency.min = 0
 
       tracker.emit('done', result)
-      if (!opts.forever) cb(null, result)
+      if (!opts.forever) {
+        latencies.destroy()
+        requests.destroy()
+        throughput.destroy()
+        cb(null, result)
+      }
 
       // the restart function
       setImmediate(() => {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "form-data": "^3.0.0",
     "has-async-hooks": "^1.0.0",
     "hdr-histogram-js": "^2.0.1",
-    "hdr-histogram-percentiles-obj": "^2.0.0",
+    "hdr-histogram-percentiles-obj": "^3.0.0",
     "http-parser-js": "^0.5.2",
     "hyperid": "^2.0.3",
     "manage-path": "^2.0.0",

--- a/test/serial/wasm.test.js
+++ b/test/serial/wasm.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const test = require('tap').test
+const run = require('../../lib/run')
+const helper = require('../helper')
+
+test('should clean up HdrHistogram WASM memory at each run', async (t) => {
+  const server = helper.startServer()
+  const runTwentyTimes = (resolve, reject, numberOfRuns = 0) => {
+    run({
+      url: 'http://localhost:' + server.address().port,
+      connections: 1,
+      amount: 1
+    }, (result) => {
+      // should get error " url or socketPath option required"
+      // we can ignore this error, we just want run() to execute
+      // and to instantiate new WASM histograms
+      if (numberOfRuns < 20) {
+        runTwentyTimes(resolve, reject, ++numberOfRuns)
+      } else {
+        resolve()
+      }
+    })
+  }
+  const lotsOfRuns = []
+  for (let index = 0; index < 50; index++) {
+    lotsOfRuns.push(new Promise(runTwentyTimes))
+  }
+
+  await Promise.all(lotsOfRuns)
+
+  // if the process has not crashed, we are good \o/
+  t.end()
+})


### PR DESCRIPTION
Hello
This PR is related to [issue 272](https://github.com/mcollina/autocannon/issues/272)
The two things that are very important when using wasm histograms are to load the binary prior to instantiation and to free the memory when the histograms are not needed anymore.
Let me know if you prefer to enable wasm histograms only when a config switch is on.