### PR TITLE
fix: Record bodies in the RequestIterator even if the body is empty.

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -2,5 +2,5 @@ esm: false
 ts: false
 jsx: false
 flow: false
-timeout: 45
+timeout: 60
 coverage: true

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -88,6 +88,8 @@ function Client (opts) {
   }
 
   this.parser[HTTPParser.kOnBody] = (body, start, len) => {
+    this.bodyRecorded = true
+
     this.emit('body', body)
     const bodyString = '' + body.slice(start, start + len)
 
@@ -108,6 +110,10 @@ function Client (opts) {
 
     if (!this.destroyed && this.reconnectRate && this.reqsMade % this.reconnectRate === 0) {
       return this._resetConnection()
+    }
+
+    if (!this.bodyRecorded) {
+      this.requestIterator.recordBody(resp.req, resp.headers.statusCode, undefined)
     }
 
     this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration, this.rate)
@@ -175,6 +181,7 @@ Client.prototype._doRequest = function (rpi) {
         this.emit('reset')
       }
     }
+    this.bodyRecorded = false
     this.resData[rpi].req = this.requestIterator.currentRequest
     this.resData[rpi].startTime = process.hrtime()
     this.conn.write(this.getRequestBuffer())

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -698,6 +698,35 @@ test('should count resets', t => {
   })
 })
 
+test('should get onResponse callback invoked even when there is no body', t => {
+  t.plan(4)
+  const server = helper.startServer({ responses: [{ statusCode: 200, body: 'ok' }, { statusCode: 204 }] })
+
+  run({
+    url: 'http://localhost:' + server.address().port,
+    connections: 1,
+    amount: 2,
+    requests: [
+      {
+        method: 'GET',
+        onResponse (status, body) {
+          t.same(status, 200)
+          t.same(body, 'ok')
+        }
+      },
+      {
+        method: 'GET',
+        onResponse (status, body) {
+          t.same(status, 204)
+          t.same(body, undefined)
+        }
+      }
+    ]
+  }).then((result) => {
+    t.end()
+  })
+})
+
 test('should use request from HAR', (t) => {
   t.plan(6)
   const server = helper.startServer()

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -698,11 +698,11 @@ test('should count resets', t => {
   })
 })
 
-test('should get onResponse callback invoked even when there is no body', t => {
+test('should get onResponse callback invoked even when there is no body', async t => {
   t.plan(4)
   const server = helper.startServer({ responses: [{ statusCode: 200, body: 'ok' }, { statusCode: 204 }] })
 
-  run({
+  await run({
     url: 'http://localhost:' + server.address().port,
     connections: 1,
     amount: 2,
@@ -722,9 +722,9 @@ test('should get onResponse callback invoked even when there is no body', t => {
         }
       }
     ]
-  }).then((result) => {
-    t.end()
   })
+
+  t.end()
 })
 
 test('should use request from HAR', (t) => {


### PR DESCRIPTION
We have noticed in our API use of autocannon that `onResponse` callback are not invoked if the server sends no body.
This PR fixes the issue.