### PR TITLE
Adding support for passing in custom tlsOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Start autocannon against the given target.
     * `servername`: A `String` identifying the server name for the SNI (Server Name Indication) TLS extension. _OPTIONAL_ default: Defaults to the hostname of the URL when it is not an IP address.
     * `excludeErrorStats`: A `Boolean` which allows you to disable tracking non 2xx code responses in latency and bytes per second calculations. _OPTIONAL_ default: `false`.
     * `expectBody`: A `String` representing the expected response body. Each request whose response body is not equal to `expectBody`is counted in `mismatches`. If enabled, mismatches count towards bailout. _OPTIONAL_
+    * `tlsOptions`: An `Object` that is passed into `tls.connect` call ([Full list of options](https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback)). Note: this only applies if your url is secure.
 * `cb`: The callback which is called on completion of a benchmark. Takes the following params. _OPTIONAL_.
     * `err`: If there was an error encountered with the run.
     * `results`: The results of the run.

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -21,6 +21,7 @@ function Client (opts) {
   const pipelining = this.opts.pipelining
   this.opts.port = this.opts.port || 80
   this.opts.expectBody = this.opts.expectBody || null
+  this.opts.tlsOptions = this.opts.tlsOptions || {}
   this.timeout = (this.opts.timeout || 10) * 1000
   this.ipc = !!this.opts.socketPath
   this.secure = this.opts.protocol === 'https:'
@@ -131,9 +132,9 @@ Client.prototype._connect = function () {
     }
 
     if (this.ipc) {
-      this.conn = tls.connect(this.opts.socketPath, { rejectUnauthorized: false })
+      this.conn = tls.connect(this.opts.socketPath, { ...this.opts.tlsOptions, rejectUnauthorized: false })
     } else {
-      this.conn = tls.connect(this.opts.port, this.opts.hostname, { rejectUnauthorized: false, servername })
+      this.conn = tls.connect(this.opts.port, this.opts.hostname, { ...this.opts.tlsOptions, rejectUnauthorized: false, servername })
     }
   } else {
     if (this.ipc) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -284,6 +284,10 @@ function _run (opts, cb, tracker) {
         url.rate = distributeNums(opts.overallRate, i)
       }
 
+      if (opts.tlsOptions) {
+        url.tlsOptions = opts.tlsOptions
+      }
+
       const client = new Client(url)
       client.on('response', onResponse)
       client.on('connError', onError)


### PR DESCRIPTION
**Why**
Currently there is no way to pass custom client certificates through autocannon if the server being benchmarked requires client certificate validation

**How**
- Adding support in the js API to pass in tlsOptions through to the httpClient.
- Updated the test tls server to echo the client certificate email as a way to verify things are working correctly