### PR TITLE
fix: attempt to fix intermittent test failures

### DIFF
--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -563,7 +563,7 @@ test('client should emit a timeout when no response is received', (t) => {
     t.ok(1, 'timeout should have happened')
   })
 
-  setTimeout(() => client.destroy(), 1500)
+  setTimeout(() => client.destroy(), 1800)
 })
 
 test('client should emit 2 timeouts when no responses are received', (t) => {
@@ -577,7 +577,7 @@ test('client should emit 2 timeouts when no responses are received', (t) => {
     t.ok(1, 'timeout should have happened')
   })
 
-  setTimeout(() => client.destroy(), 2500)
+  setTimeout(() => client.destroy(), 2800)
 })
 
 test('client should have 2 different requests it iterates over', (t) => {

--- a/test/runRate.test.js
+++ b/test/runRate.test.js
@@ -16,7 +16,7 @@ test('run should only send the expected number of requests per second - scenario
   }, (err, res) => {
     t.error(err)
 
-    t.equal(Math.round(res.duration), 4, 'should have take 4 seconds to send 10 requests per seconds')
+    t.equal(Math.floor(res.duration), 4, 'should have take 4 seconds to send 10 requests per seconds')
     t.equal(res.requests.average, 10, 'should have sent 10 requests per second on average')
   })
 })
@@ -31,7 +31,7 @@ test('run should only send the expected number of requests per second - scenario
     amount: 40
   }, (err, res) => {
     t.error(err)
-    t.equal(Math.round(res.duration), 2, 'should have taken 2 seconds to send 10 requests per connection with 2 connections')
+    t.equal(Math.floor(res.duration), 2, 'should have taken 2 seconds to send 10 requests per connection with 2 connections')
     t.equal(res.requests.average, 20, 'should have sent 20 requests per second on average with two connections')
   })
 })
@@ -46,7 +46,7 @@ test('run should only send the expected number of requests per second - scenario
     amount: 40
   }, (err, res) => {
     t.error(err)
-    t.equal(Math.round(res.duration), 4, 'should have take 4 seconds to send 10 requests per seconds')
+    t.equal(Math.floor(res.duration), 4, 'should have take 4 seconds to send 10 requests per seconds')
     t.equal(res.requests.average, 10, 'should have sent 10 requests per second on average')
   })
 })


### PR DESCRIPTION
Builds are still not very stable on windows CI.
Although we tried running on windows machine locally but could never see a test fail.

### In `httpClient.test.js`

It seems like these two tests in `httpClient.test.js` are failing intermittently. 

- client should emit a timeout when no response is received
- client should emit 2 timeouts when no responses are received

This PR increases wait time from 2500 to 2800, just so slow windows boxes don't choke up. 

### in `runRate.test.js`

All 3 scenarios of the following test are failing intermittently. 

- run should only send the expected number of requests per second

I presume the `duration` may be coming as slightly more than 4.5 seconds due to slow windows box and becomes `5` due to `Math.round`. But we're asserting it with `4`, so I've changed it to `Math.floor` instead.