### PR TITLE
fix: test checking duration of request with pipeline

### DIFF
--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -74,7 +74,7 @@ test('client calculates correct duration when using pipelining', (t) => {
 
   client.on('response', (statusCode, length, duration) => {
     t.equal(statusCode, 200, 'status code matches')
-    t.ok(duration > 500 && duration < 600)
+    t.ok(duration > 500 && duration < 800)
 
     if (++count === 2) {
       client.destroy()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2510597/102605664-9c907e80-414b-11eb-9fce-310594b48396.png)

Tests are failing on MacOS 10. May be 600 ms isn't enough time, so increased it to 800