### PR TITLE
fix: broken test with node 15

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -36,7 +36,10 @@ function startServer (opts) {
     }
 
     res.statusCode = statusCode
-    const reply = () => res.end(typeof body === 'function' ? body(req) : body)
+    const reply = () => {
+      const bodyToWrite = typeof body === 'function' ? body(req) : body
+      res.end(statusCode < 200 ? undefined : bodyToWrite)
+    }
 
     if (opts.delayResponse) {
       setTimeout(reply, opts.delayResponse)

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -3,12 +3,10 @@
 const os = require('os')
 const path = require('path')
 const test = require('tap').test
-const semver = require('semver')
 const initJob = require('../lib/init')
 const defaultOptions = require('../lib/defaultOptions')
 const helper = require('./helper')
 const server = helper.startServer()
-const isNode15 = semver.gte(process.versions.node, '15.0.0')
 
 test('init', (t) => {
   initJob({
@@ -368,8 +366,7 @@ test('run should accept a unix socket/windows pipe', (t) => {
 })
 
 for (let i = 1; i <= 5; i++) {
-  // TODO we should not skip those tests
-  test(`run should count all ${i}xx status codes`, { skip: isNode15 }, (t) => {
+  test(`run should count all ${i}xx status codes`, (t) => {
     const server = helper.startServer({ statusCode: i * 100 + 2 })
 
     initJob({


### PR DESCRIPTION
```js
  const server = http.createServer((req, res) => {
    res.statusCode = 102
    res.end('Hello')
  })
  server.listen(9000)
```

This simple http server responds differently in Node v14 vs v15. 

**Response in Node v14**

```
HTTP/1.1 102 Processing
Date: Thu, 21 Jan 2021 15:22:09 GMT
Connection: close
```

**Response in Node v15**

```
HTTP/1.1 102 Processing
Date: Thu, 21 Jan 2021 15:22:09 GMT
Connection: close
Content-Length: 5 // <---
```

I haven't done a thorough research with node and http specs as to why this behaviour is different but as I understand, the `102` response doesn't return a body. But if you try to send it, Node 14 smartly ignores it and does not send a `Content-Length` header. However Node 15 sends this header, which is why `http-parser-js` waits for the body and never fires `kOnMessageComplete`.