### PR TITLE
feat: implement request titles

### DIFF
--- a/lib/aggregateResult.js
+++ b/lib/aggregateResult.js
@@ -2,15 +2,24 @@
 
 const { decodeHist, histAsObj, addPercentiles } = require('./histUtil')
 
-function aggregateResult (results, opts, histograms) {
+// TODO: the third parameter is not used yet. It should?
+function aggregateResult (results, opts, requestHistograms) {
   results = Array.isArray(results) ? results : [results]
 
-  const aggregated = results.map(r => ({
-    ...r,
-    latencies: decodeHist(r.latencies),
-    requests: decodeHist(r.requests),
-    throughput: decodeHist(r.throughput)
-  })).reduce((acc, r) => {
+  const aggregated = results.map(r => {
+    return {
+      ...r,
+      requests: r.requests.map((req) => {
+        return {
+          ...req,
+          latencies: decodeHist(req.latencies),
+          requests: decodeHist(req.requests),
+          throughput: decodeHist(req.throughput),
+        }
+      }),
+    }
+  }).reduce((acc, r) => {
+    // TODO not fully compatible
     acc.latencies.add(r.latencies)
 
     acc.totalCompletedRequests += r.totalCompletedRequests
@@ -53,17 +62,25 @@ function aggregateResult (results, opts, histograms) {
     '4xx': aggregated['4xx'],
     '5xx': aggregated['5xx'],
 
-    latency: addPercentiles(aggregated.latencies, histAsObj(aggregated.latencies)),
-    requests: addPercentiles(histograms.requests, histAsObj(histograms.requests, aggregated.totalCompletedRequests)),
-    throughput: addPercentiles(histograms.throughput, histAsObj(histograms.throughput, aggregated.totalBytes))
+    requests: aggregated.requests.map((r) => {
+      return {
+        ...r,
+        latencies: addPercentiles(r.latencies, histAsObj(r.latencies)),
+        requests: addPercentiles(r.requests, histAsObj(r.requests, aggregated.totalCompletedRequests)),
+        throughput: addPercentiles(r.throughput, histAsObj(r.throughput, aggregated.totalBytes)),
+      }
+    })
+    // latency: addPercentiles(aggregated.latencies, histAsObj(aggregated.latencies)),
+    // requests: addPercentiles(histograms.requests, histAsObj(histograms.requests, aggregated.totalCompletedRequests)),
+    // throughput: addPercentiles(histograms.throughput, histAsObj(histograms.throughput, aggregated.totalBytes))
   }
 
-  result.latency.totalCount = aggregated.latencies.totalCount
-  result.requests.sent = aggregated.totalRequests
+  // result.latency.totalCount = aggregated.latencies.totalCount
+  // result.requests.sent = aggregated.totalRequests
 
-  if (result.requests.min >= Number.MAX_SAFE_INTEGER) result.requests.min = 0
-  if (result.throughput.min >= Number.MAX_SAFE_INTEGER) result.throughput.min = 0
-  if (result.latency.min >= Number.MAX_SAFE_INTEGER) result.latency.min = 0
+  // if (result.requests.min >= Number.MAX_SAFE_INTEGER) result.requests.min = 0
+  // if (result.throughput.min >= Number.MAX_SAFE_INTEGER) result.throughput.min = 0
+  // if (result.latency.min >= Number.MAX_SAFE_INTEGER) result.latency.min = 0
 
   return result
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,4 +1,9 @@
 'use strict'
+// TODO:
+// Parse StatusCode
+// StatusCode numbers is not reliable
+// Check the other values
+
 
 const URL = require('url')
 const reInterval = require('reinterval')
@@ -17,27 +22,32 @@ function run (opts, tracker, cb) {
   opts = Object.assign({}, defaults, opts)
   tracker = tracker || new EE()
 
-  const histograms = getHistograms(opts.histograms)
-  const { latencies, requests, throughput } = histograms
-
-  const statusCodes = [
-    0, // 1xx
-    0, // 2xx
-    0, // 3xx
-    0, // 4xx
-    0 // 5xx
-  ]
+  const requestHistograms = opts.requests.map((req) => {
+    return {
+      [req.title]: {
+        title: req.title,
+        ...getHistograms(opts.getHistograms),
+        statusCodes: [
+          0, // 1xx
+          0, // 2xx
+          0, // 3xx
+          0, // 4xx
+          0 // 5xx
+        ],
+        bytes: 0,
+        counter: 0,
+      },
+    }
+  }).reduce((prev, curr) => ({ ...prev, ...curr }), {})
 
   if (opts.overallRate && (opts.overallRate < opts.connections)) opts.connections = opts.overallRate
 
-  let counter = 0
-  let bytes = 0
   let errors = 0
   let timeouts = 0
-  let mismatches = 0
   let totalBytes = 0
   let totalRequests = 0
   let totalCompletedRequests = 0
+  let mismatches = 0
   let resets = 0
   const amount = opts.amount
   let stop = false
@@ -93,47 +103,72 @@ function run (opts, tracker, cb) {
   setImmediate(() => { tracker.emit('start') })
 
   function tickInterval () {
-    totalBytes += bytes
-    totalCompletedRequests += counter
-    requests.recordValue(counter)
-    throughput.recordValue(bytes)
-    tracker.emit('tick', { counter, bytes })
-    counter = 0
-    bytes = 0
+    Object.values(requestHistograms).forEach((req, idx) => {
+      totalBytes += req.bytes
+      totalCompletedRequests += req.counter
+
+      req.requests.recordValue(req.counter)
+      req.throughput.recordValue(req.bytes)
+      tracker.emit('tick', { requestIndex: idx, counter: req.counter, bytes: req.bytes })
+
+      req.bytes = 0
+      req.counter = 0
+    })
 
     if (stop) {
       if (stopTimer) clearTimeout(stopTimer)
       interval.clear()
       clients.forEach((client) => client.destroy())
       const result = {
-        latencies: encodeHist(latencies),
-        requests: encodeHist(requests),
-        throughput: encodeHist(throughput),
+        requests: Object.values(requestHistograms).map((req) => {
+          return {
+            ...req,
+            latencies: encodeHist(req.latencies),
+            requests: encodeHist(req.requests),
+            throughput: encodeHist(req.throughput),
+          }
+        }),
         totalCompletedRequests,
         totalRequests,
         totalBytes,
         errors: errors,
         timeouts: timeouts,
         mismatches: mismatches,
-        non2xx: statusCodes[0] + statusCodes[2] + statusCodes[3] + statusCodes[4],
+        non2xx: 0,
         resets: resets,
         duration: Math.round((Date.now() - startTime) / 10) / 100,
         start: new Date(startTime),
         finish: new Date()
       }
 
-      statusCodes.forEach((code, index) => { result[(index + 1) + 'xx'] = code })
+      Object.values(requestHistograms).forEach((req, reqIdx) => {
+        result.requests[reqIdx].status = {}
 
-      const resultObj = isMainThread ? aggregateResult(result, opts, histograms) : result
+        req.statusCodes.forEach((code, index) => {
+          if (index !== 1 /* 2xx */) {
+            result.non2xx += code
+          }
+          result[(index + 1) + 'xx'] = (result[(index + 1) + 'xx'] || 0) + code
+          result.requests[reqIdx].status[(index + 1) + 'xx'] = code
+        })
+
+        delete result.requests[reqIdx].statusCodes
+        delete result.requests[reqIdx].bytes
+        delete result.requests[reqIdx].counter
+      })
+
+      const resultObj = isMainThread ? aggregateResult(result, opts, requestHistograms) : result
 
       if (opts.forever) {
         // we don't call callback when in forever mode, so this is the
         // only place we could notify user when each round finishes
         tracker.emit('done', resultObj)
       } else {
-        latencies.destroy()
-        requests.destroy()
-        throughput.destroy()
+        Object.values(requestHistograms).forEach(r => {
+          r.latencies.destroy()
+          r.requests.destroy()
+          r.throughput.destroy()
+        })
         cb(null, resultObj)
       }
 
@@ -213,19 +248,21 @@ function run (opts, tracker, cb) {
     }
 
     function onResponse (statusCode, resBytes, responseTime, rate) {
-      tracker.emit('response', this, statusCode, resBytes, responseTime)
+      tracker.emit('response', this, statusCode, resBytes, responseTime, this.requestIterator.currentRequest)
       const codeIndex = Math.floor(parseInt(statusCode) / 100) - 1
-      statusCodes[codeIndex] += 1
+      requestHistograms[this.requestIterator.currentRequest.title].statusCodes[codeIndex] += 1
       // only recordValue 2xx latencies
       if (codeIndex === 1 || includeErrorStats) {
         if (rate && !opts.ignoreCoordinatedOmission) {
-          latencies.recordValueWithExpectedInterval(responseTime, Math.ceil(1 / rate))
+          requestHistograms[this.requestIterator.currentRequest.title].latencies.recordValueWithExpectedInterval(responseTime, Math.ceil(1 / rate))
         } else {
-          latencies.recordValue(responseTime)
+          requestHistograms[this.requestIterator.currentRequest.title].latencies.recordValue(responseTime)
         }
       }
-      if (codeIndex === 1 || includeErrorStats) bytes += resBytes
-      counter++
+      if (codeIndex === 1 || includeErrorStats) {
+        requestHistograms[this.requestIterator.currentRequest.title].bytes += resBytes
+      }
+      requestHistograms[this.requestIterator.currentRequest.title].counter++
     }
 
     function onError (error) {

--- a/samples/requests-sample.js
+++ b/samples/requests-sample.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const http = require('http')
-const autocannon = require('autocannon')
+const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)
 
@@ -24,6 +24,7 @@ function startBench () {
     },
     requests: [
       {
+        title: '1-',
         method: 'POST', // this should be a post for logging in
         path: '/login',
         body: 'valid login details',
@@ -33,10 +34,12 @@ function startBench () {
         headers: {}
       },
       {
+        title: '2-',
         path: '/mySecretDetails'
         // this will automatically add the pregenerated auth token
       },
       {
+        title: '3-',
         method: 'GET', // this should be a put for modifying secret details
         path: '/mySecretDetails',
         headers: { // let submit some json?
@@ -55,6 +58,7 @@ function startBench () {
   }, finishedBench)
 
   function finishedBench (err, res) {
-    console.log('finished bench', err, res)
+    console.log('finished bench', err)
+    console.dir(res, { depth: 4 })
   }
 }


### PR DESCRIPTION
Obs: This is just a sketch just to validate if we can reach the goal. The things need to be refactored and cover some paths.

Ref #319 

<details>
  <summary>Result example of `samples/requests-sample.js` - Click here!</summary>
  
```sh
{
  title: undefined,
  url: 'http://localhost:41135',
  socketPath: undefined,
  connections: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 10.32,
  start: 2021-01-27T00:07:40.581Z,
  finish: 2021-01-27T00:07:50.905Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 225408,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  requests: [
    {
      title: '1-',
      latencies: {
        average: 45.71,
        mean: 45.71,
        stddev: 97.15,
        min: 17,
        max: 1255,
        p0_001: 17,
        p0_01: 17,
        p0_1: 17,
        p1: 18,
        p2_5: 19,
        p10: 35,
        p25: 36,
        p50: 36,
        p75: 38,
        p90: 40,
        p97_5: 45,
        p99: 331,
        p99_9: 1237,
        p99_99: 1253,
        p99_999: 1255
      },
      requests: {
        average: 7565.2,
        mean: 7565.2,
        stddev: 844.1,
        min: 5120,
        max: 8003,
        total: 225408,
        p0_001: 5123,
        p0_01: 5123,
        p0_1: 5123,
        p1: 5123,
        p2_5: 5123,
        p10: 5123,
        p25: 7515,
        p50: 8003,
        p75: 8003,
        p90: 8003,
        p97_5: 8003,
        p99: 8003,
        p99_9: 8003,
        p99_99: 8003,
        p99_999: 8003
      },
      throughput: {
        average: 1013299.2,
        mean: 1013299.2,
        stddev: 112913.23,
        min: 686080,
        max: 1072127,
        total: 30204672,
        p0_001: 686591,
        p0_01: 686591,
        p0_1: 686591,
        p1: 686591,
        p2_5: 686591,
        p10: 686591,
        p25: 1007103,
        p50: 1072127,
        p75: 1072127,
        p90: 1072127,
        p97_5: 1072127,
        p99: 1072127,
        p99_9: 1072127,
        p99_99: 1072127,
        p99_999: 1072127
      },
      status: { '1xx': 0, '2xx': 75632, '3xx': 0, '4xx': 0, '5xx': 0 }
    },
    {
      title: '2-',
      latencies: {
        average: 43.62,
        mean: 43.62,
        stddev: 7.78,
        min: 15,
        max: 76,
        p0_001: 15,
        p0_01: 15,
        p0_1: 16,
        p1: 19,
        p2_5: 21,
        p10: 37,
        p25: 40,
        p50: 44,
        p75: 49,
        p90: 52,
        p97_5: 55,
        p99: 58,
        p99_9: 73,
        p99_99: 75,
        p99_999: 76
      },
      requests: {
        average: 7516.4,
        mean: 7516.4,
        stddev: 994.32,
        min: 4608,
        max: 8027,
        total: 225408,
        p0_001: 4611,
        p0_01: 4611,
        p0_1: 4611,
        p1: 4611,
        p2_5: 4611,
        p10: 4611,
        p25: 7515,
        p50: 8003,
        p75: 8003,
        p90: 8003,
        p97_5: 8027,
        p99: 8027,
        p99_9: 8027,
        p99_99: 8027,
        p99_999: 8027
      },
      throughput: {
        average: 1006848,
        mean: 1006848,
        stddev: 133095.44,
        min: 617472,
        max: 1076223,
        total: 30204672,
        p0_001: 617983,
        p0_01: 617983,
        p0_1: 617983,
        p1: 617983,
        p2_5: 617983,
        p10: 617983,
        p25: 1007103,
        p50: 1072127,
        p75: 1072127,
        p90: 1072127,
        p97_5: 1076223,
        p99: 1076223,
        p99_9: 1076223,
        p99_99: 1076223,
        p99_999: 1076223
      },
      status: { '1xx': 0, '2xx': 75144, '3xx': 0, '4xx': 0, '5xx': 0 }
    },
    {
      title: '3-',
      latencies: {
        average: 45,
        mean: 45,
        stddev: 7.93,
        min: 18,
        max: 86,
        p0_001: 18,
        p0_01: 18,
        p0_1: 19,
        p1: 21,
        p2_5: 23,
        p10: 38,
        p25: 41,
        p50: 46,
        p75: 50,
        p90: 52,
        p97_5: 58,
        p99: 61,
        p99_9: 84,
        p99_99: 86,
        p99_999: 86
      },
      requests: {
        average: 7465.2,
        mean: 7465.2,
        stddev: 1003.85,
        min: 4608,
        max: 8003,
        total: 225408,
        p0_001: 4611,
        p0_01: 4611,
        p0_1: 4611,
        p1: 4611,
        p2_5: 4611,
        p10: 4611,
        p25: 7491,
        p50: 8003,
        p75: 8003,
        p90: 8003,
        p97_5: 8003,
        p99: 8003,
        p99_9: 8003,
        p99_99: 8003,
        p99_999: 8003
      },
      throughput: {
        average: 999884.8,
        mean: 999884.8,
        stddev: 134315.56,
        min: 617472,
        max: 1072127,
        total: 30204672,
        p0_001: 617983,
        p0_01: 617983,
        p0_1: 617983,
        p1: 617983,
        p2_5: 617983,
        p10: 617983,
        p25: 1003519,
        p50: 1072127,
        p75: 1072127,
        p90: 1072127,
        p97_5: 1072127,
        p99: 1072127,
        p99_9: 1072127,
        p99_99: 1072127,
        p99_999: 1072127
      },
      status: { '1xx': 0, '2xx': 74632, '3xx': 0, '4xx': 0, '5xx': 0 }
    }
  ]
}
```
</details>

Also, I'm not sure if the results are consistent. @mcollina What do you think, it would be a great feature with this structure or perhaps a way to extend the `autocannon` and provide a plugin with this approach is better?