### PR TITLE
fix: Reuse headers when set - fixes #280

### DIFF
--- a/lib/requestIterator.js
+++ b/lib/requestIterator.js
@@ -11,6 +11,7 @@ function RequestIterator (opts) {
   }
 
   this.resetted = false
+  this.headers = {}
   this.initialContext = opts.initialContext || {}
   this.resetContext()
   this.reqDefaults = opts
@@ -61,7 +62,8 @@ RequestIterator.prototype.setRequests = function (newRequests) {
 }
 
 RequestIterator.prototype.setHeaders = function (newHeaders) {
-  this.currentRequest.headers = newHeaders || {}
+  this.headers = newHeaders || {}
+  this.currentRequest.headers = this.headers
   this.rebuildRequest()
 }
 
@@ -71,7 +73,8 @@ RequestIterator.prototype.setBody = function (newBody) {
 }
 
 RequestIterator.prototype.setHeadersAndBody = function (newHeaders, newBody) {
-  this.currentRequest.headers = newHeaders || {}
+  this.headers = newHeaders || {}
+  this.currentRequest.headers = this.headers
   this.currentRequest.body = newBody || Buffer.alloc(0)
   this.rebuildRequest()
 }
@@ -85,6 +88,7 @@ RequestIterator.prototype.rebuildRequest = function () {
   let data
   this.resetted = false
   if (this.currentRequest) {
+    this.currentRequest.headers = this.headers
     data = this.requestBuilder(this.currentRequest, this.context)
     if (data) {
       this.currentRequest.requestBuffer = this.reqDefaults.idReplacement


### PR DESCRIPTION
Thanks for creating and maintaining `autocannon`. I really enjoy using this software.

I was running tests on an AWS API Gateway where I needed to configure a fixed set of headers for a couple of requests when I encountered the same issue as in #280 .

I went ahead and tried to fix it. All feedback is welcome and I'll try to update as quick as possible.