### PR TITLE
Update some more tests relying on timeouts

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -64,15 +64,15 @@ function Client (opts) {
   this.opts.setupClient(this)
 
   const handleTimeout = () => {
-    // all pipelined requests have timed out here
-    this.resData.forEach(() => this.emit('timeout'))
     this.cer = 0
     this._destroyConnection()
 
-    // timeout has already occured, need to set a new timeoutTicker
-    this.timeoutTicker = retimer(handleTimeout, this.timeout)
+    this.timeoutTicker.reschedule(this.timeout)
 
     this._connect()
+
+    // all pipelined requests have timed out here
+    this.resData.forEach(() => this.emit('timeout'))
   }
 
   if (this.rate) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",
     "reinterval": "^1.1.0",
-    "retimer": "^2.0.0",
+    "retimer": "^3.0.0",
     "semver": "^7.3.2",
     "timestring": "^6.0.0"
   }

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,9 +581,7 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
-
-    // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
-    setTimeout(() => client.destroy())
+    client.destroy()
   })
 })
 
@@ -597,8 +595,7 @@ test('client should emit 2 timeouts when no responses are received', (t) => {
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
     if (count++ > 0) {
-      // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
-      setTimeout(() => client.destroy())
+      client.destroy()
     }
   })
 })

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,9 +581,10 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
+    
+    // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
+    setTimeout(() => client.destroy())
   })
-
-  setTimeout(() => client.destroy(), 1800)
 })
 
 test('client should emit 2 timeouts when no responses are received', (t) => {
@@ -592,12 +593,14 @@ test('client should emit 2 timeouts when no responses are received', (t) => {
   const opts = timeoutServer.address()
   opts.timeout = 1
   const client = new Client(opts)
-
+  let count = 0
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
+    if (count++ > 0) {
+      // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
+      setTimeout(() => client.destroy())
+    }
   })
-
-  setTimeout(() => client.destroy(), 2800)
 })
 
 test('client should have 2 different requests it iterates over', (t) => {

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,7 +581,7 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
-    
+
     // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
     setTimeout(() => client.destroy())
   })

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -66,7 +66,8 @@ test('client calls a https server twice', (t) => {
 test('client calculates correct duration when using pipelining', (t) => {
   t.plan(4)
 
-  const lazyServer = helper.startServer({ delayResponse: 500 })
+  const delayResponse = 500
+  const lazyServer = helper.startServer({ delayResponse })
   const opts = lazyServer.address()
   opts.pipelining = 2
   const client = new Client(opts)
@@ -74,7 +75,7 @@ test('client calculates correct duration when using pipelining', (t) => {
 
   client.on('response', (statusCode, length, duration) => {
     t.equal(statusCode, 200, 'status code matches')
-    t.ok(duration > 500 && duration < 800)
+    t.ok(duration > delayResponse, `Expected response delay > ${delayResponse}ms but got ${duration}ms`)
 
     if (++count === 2) {
       client.destroy()


### PR DESCRIPTION
@mcollina this should help further.

However, I don't like the fix here because as a user of `httpClient` I would expect for `client.destroy()` to work regardless of when it is called. In the current implementation, `client.destroy()` will not work as expected if invoked synchronously in a timeout handler. It does not clear the retry mechanism of the `httpClient`.

I think the "right" fix consists in using a different version of `retimer` that allows to reset the timer after it has been triggered. This way there is no need to change the instance of retimer within the `httpClient`.

Cf. https://github.com/mcollina/autocannon/blob/f8b598e103644e5048f9a936d6ac3b746986285e/lib/httpClient.js#L73