### PR TITLE
fix: do not show warnings when workers >= 10

### DIFF
--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -8,7 +8,7 @@
 const ProgressBar = require('progress')
 const Chalk = require('chalk')
 const testColorSupport = require('color-support')
-const ora = require('ora')
+const charSpinner = require('char-spinner')
 const printResult = require('./printResult')
 const { isMainThread } = require('./worker_threads')
 const defaults = {
@@ -79,13 +79,12 @@ function track (instance, opts) {
   })
 
   function showSpinner () {
-    spinner = ora('running...')
-    spinner.start()
+    spinner = charSpinner()
   }
 
   function hideSpinner () {
     if (spinner) {
-      spinner.stop()
+      clearInterval(spinner)
       spinner = null
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "busboy": "^0.3.1",
     "pre-commit": "^1.1.2",
     "proxyquire": "^2.1.3",
+    "sinon": "^9.2.4",
     "split2": "^3.2.2",
     "standard": "^16.0.3",
     "tap": "^14.10.8"
   },
   "dependencies": {
     "chalk": "^4.1.0",
+    "char-spinner": "^1.0.1",
     "cli-table3": "^0.6.0",
     "clone": "^2.1.2",
     "color-support": "^1.1.1",
@@ -61,7 +63,6 @@
     "manage-path": "^2.0.0",
     "minimist": "^1.2.0",
     "on-net-listen": "^1.1.1",
-    "ora": "^5.1.0",
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",
     "reinterval": "^1.1.0",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -205,7 +205,6 @@ test('run with workers', { skip: !hasWorkerSupport }, (t) => {
     /4 workers.*$/,
     /$/,
     /.*/,
-    /.*/, // spinner text is shown even though it's supposed to be cleared
     /Stat.*2\.5%.*50%.*97\.5%.*99%.*Avg.*Stdev.*Max.*$/,
     /.*/,
     /Latency.*$/,


### PR DESCRIPTION
Replaces ora with char-spinner to avoid the warning altogether.

### old explanation

I didn't actually figure out the root cause of why this is happening, and I do realize that making this initialization eager is doing something that's probably unnecessary unless workers are being used. Nevertheless, that's the most reliable way I found to fix this.

The problem seems to come from the bl package used by ora, which does some fancy stream manipulation, eventually leading to the warnings being generated.

Making the initialization of ora eager in the module root makes the issue disappear. 

Closes #337 