### PR TITLE
Ensure there are tests for calculating the duration of pipelined requests

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -9,6 +9,7 @@ const HTTPParser = require('http-parser-js').HTTPParser
 const RequestIterator = require('./requestIterator')
 const noop = require('./noop')
 const clone = require('clone')
+const PipelinedRequestsQueue = require('./pipelinedRequestsQueue')
 
 function Client (opts) {
   if (!(this instanceof Client)) {
@@ -19,7 +20,6 @@ function Client (opts) {
 
   this.opts.setupClient = this.opts.setupClient || noop
   this.opts.pipelining = this.opts.pipelining || 1
-  const pipelining = this.opts.pipelining
   this.opts.port = this.opts.port || 80
   this.opts.expectBody = this.opts.expectBody || null
   this.opts.tlsOptions = this.opts.tlsOptions || {}
@@ -47,32 +47,23 @@ function Client (opts) {
   // used for forcing reconnects
   this.reconnectRate = this.opts.reconnectRate
 
-  this.resData = new Array(pipelining)
-  for (let i = 0; i < pipelining; i++) {
-    this.resData[i] = {
-      bytes: 0,
-      body: '',
-      headers: {},
-      startTime: [0, 0]
-    }
-  }
-
-  // cer = current expected response
-  this.cer = 0
+  this.pipelinedRequests = new PipelinedRequestsQueue()
   this.destroyed = false
 
   this.opts.setupClient(this)
 
   const handleTimeout = () => {
-    this.cer = 0
     this._destroyConnection()
 
     this.timeoutTicker.reschedule(this.timeout)
+    // all pipelined requests have timed out here
+    // this.pipelinedRequests.toArray().forEach(() => this.emit('timeout'))
 
     this._connect()
 
-    // all pipelined requests have timed out here
-    this.resData.forEach(() => this.emit('timeout'))
+    for (let i = 0; i < this.opts.pipelining; i++) {
+      this.emit('timeout')
+    }
   }
 
   if (this.rate) {
@@ -87,39 +78,31 @@ function Client (opts) {
   this.parser[HTTPParser.kOnHeaders] = () => {}
   this.parser[HTTPParser.kOnHeadersComplete] = (opts) => {
     this.emit('headers', opts)
-    this.resData[this.cer].headers = opts
+    this.pipelinedRequests.setHeaders(opts)
   }
 
   this.parser[HTTPParser.kOnBody] = (body, start, len) => {
-    this.resData[this.cer].body += body.slice(start, start + len)
+    this.pipelinedRequests.addBody(body.slice(start, start + len))
     this.emit('body', body)
   }
 
   this.parser[HTTPParser.kOnMessageComplete] = () => {
-    const resp = this.resData[this.cer]
-    const end = process.hrtime(resp.startTime)
-    resp.duration = end[0] * 1e3 + end[1] / 1e6
+    const resp = this.pipelinedRequests.terminateRequest()
 
     if (!this.destroyed && this.reconnectRate && this.reqsMade % this.reconnectRate === 0) {
       return this._resetConnection()
     }
+    if (!this.destroyed) {
+      if (this.opts.expectBody && this.opts.expectBody !== resp.body) {
+        return this.emit('mismatch', resp.body)
+      }
 
-    if (this.opts.expectBody && this.opts.expectBody !== resp.body) {
-      return this.emit('mismatch', resp.body)
+      this.requestIterator.recordBody(resp.req, resp.headers.statusCode, resp.body)
+
+      this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration, this.rate)
+
+      this._doRequest()
     }
-
-    this.requestIterator.recordBody(resp.req, resp.headers.statusCode, resp.body)
-
-    this.emit('response', resp.headers.statusCode, resp.bytes, resp.duration, this.rate)
-
-    // Separating rip ensures that after getting response for first request, we fire
-    // first one again because second is already running right now (with pipelining=2).
-    // See detailed explaination at https://github.com/mcollina/autocannon/pull/317#discussion_r543678831
-    const rpi = (this.cer + pipelining) % pipelining
-    resp.body = ''
-    resp.bytes = 0
-    this.cer = (this.cer + 1) % pipelining
-    this._doRequest(rpi)
   }
 
   this._connect()
@@ -155,7 +138,7 @@ Client.prototype._connect = function () {
   })
 
   this.conn.on('data', (chunk) => {
-    this.resData[this.cer].bytes += chunk.length
+    this.pipelinedRequests.addByteCount(chunk.length)
     this.parser.execute(chunk)
   })
 
@@ -164,12 +147,11 @@ Client.prototype._connect = function () {
   })
 
   for (let i = 0; i < this.opts.pipelining; i++) {
-    this._doRequest(i)
+    this._doRequest()
   }
 }
 
-// rpi = request pipelining index
-Client.prototype._doRequest = function (rpi) {
+Client.prototype._doRequest = function () {
   if (!this.rate || (this.rate && this.reqsMadeThisSecond++ < this.rate)) {
     if (!this.destroyed && this.responseMax && this.reqsMade >= this.responseMax) {
       return this.destroy()
@@ -181,8 +163,7 @@ Client.prototype._doRequest = function (rpi) {
         this.emit('reset')
       }
     }
-    this.resData[rpi].req = this.requestIterator.currentRequest
-    this.resData[rpi].startTime = process.hrtime()
+    this.pipelinedRequests.insertRequest(this.requestIterator.currentRequest)
     this.conn.write(this.getRequestBuffer())
     this.timeoutTicker.reschedule(this.timeout)
     this.reqsMade++
@@ -201,6 +182,7 @@ Client.prototype._destroyConnection = function () {
   this.conn.removeAllListeners('end')
   this.conn.on('error', () => {})
   this.conn.destroy()
+  this.pipelinedRequests.clear()
 }
 
 Client.prototype.destroy = function () {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -64,15 +64,15 @@ function Client (opts) {
   this.opts.setupClient(this)
 
   const handleTimeout = () => {
-    // all pipelined requests have timed out here
-    this.resData.forEach(() => this.emit('timeout'))
     this.cer = 0
     this._destroyConnection()
 
-    // timeout has already occured, need to set a new timeoutTicker
-    this.timeoutTicker = retimer(handleTimeout, this.timeout)
+    this.timeoutTicker.reschedule(this.timeout)
 
     this._connect()
+
+    // all pipelined requests have timed out here
+    this.resData.forEach(() => this.emit('timeout'))
   }
 
   if (this.rate) {

--- a/lib/pipelinedRequestsQueue.js
+++ b/lib/pipelinedRequestsQueue.js
@@ -1,0 +1,78 @@
+/**
+ * A queue (FIFO) to hold pipelined requests and link metadata to them as the response is received from the server.
+ * This facilitates the handling of responses when the HTTP requests are pipelined.
+ * A queue is the best structure for this because the sever reponses are provided in the same order as the requests
+ * Cf. https://en.wikipedia.org/wiki/HTTP_pipelining
+ *
+ * /!\ it's up to you as a user to ensure that the queue is populated if using
+ * the functionality. This implementation will fail silently if e.g. you try to
+ * call any function accessing the queue while it's empty.
+ */
+class PipelinedRequestsQueue {
+  constructor () {
+    this.pendingRequests = []
+  }
+
+  insertRequest (req) {
+    this.pendingRequests.push({
+      req,
+      bytes: 0,
+      body: '',
+      headers: {},
+      startTime: process.hrtime()
+    })
+  }
+
+  peek () {
+    if (this.pendingRequests.length > 0) {
+      return this.pendingRequests[0]
+    }
+  }
+
+  addByteCount (count) {
+    const req = this.peek()
+    if (req) {
+      req.bytes += count
+    }
+  }
+
+  addBody (data) {
+    const req = this.peek()
+    if (req) {
+      req.body += data
+    }
+  }
+
+  setHeaders (headers) {
+    const req = this.peek()
+    if (req) {
+      req.headers = headers
+    }
+  }
+
+  size () {
+    return this.pendingRequests.length
+  }
+
+  /** Terminates the first-in request
+   * This will calculate the request duration, remove it from the queue and return its data
+   **/
+  terminateRequest () {
+    if (this.pendingRequests.length > 0) {
+      const data = this.pendingRequests.shift()
+      const hrduration = process.hrtime(data.startTime)
+      data.duration = hrduration[0] * 1e3 + hrduration[1] / 1e6
+      return data
+    }
+  }
+
+  clear () {
+    this.pendingRequests = []
+  }
+
+  toArray () {
+    return this.pendingRequests
+  }
+}
+
+module.exports = PipelinedRequestsQueue

--- a/lib/pipelinedRequestsQueue.js
+++ b/lib/pipelinedRequestsQueue.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * A queue (FIFO) to hold pipelined requests and link metadata to them as the response is received from the server.
  * This facilitates the handling of responses when the HTTP requests are pipelined.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",
     "reinterval": "^1.1.0",
-    "retimer": "^2.0.0",
+    "retimer": "^3.0.0",
     "semver": "^7.3.2",
     "timestring": "^6.0.0"
   }

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,9 +581,7 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
-
-    // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
-    setTimeout(() => client.destroy())
+    client.destroy()
   })
 })
 
@@ -597,8 +595,7 @@ test('client should emit 2 timeouts when no responses are received', (t) => {
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
     if (count++ > 0) {
-      // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
-      setTimeout(() => client.destroy())
+      client.destroy()
     }
   })
 })

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,9 +581,10 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
+    
+    // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
+    setTimeout(() => client.destroy())
   })
-
-  setTimeout(() => client.destroy(), 1800)
 })
 
 test('client should emit 2 timeouts when no responses are received', (t) => {
@@ -592,12 +593,14 @@ test('client should emit 2 timeouts when no responses are received', (t) => {
   const opts = timeoutServer.address()
   opts.timeout = 1
   const client = new Client(opts)
-
+  let count = 0
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
+    if (count++ > 0) {
+      // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
+      setTimeout(() => client.destroy())
+    }
   })
-
-  setTimeout(() => client.destroy(), 2800)
 })
 
 test('client should have 2 different requests it iterates over', (t) => {

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -581,7 +581,7 @@ test('client should emit a timeout when no response is received', (t) => {
 
   client.on('timeout', () => {
     t.ok(1, 'timeout should have happened')
-    
+
     // client.destroy must be done async to ensure the correct internal timer is destroyed instead of the one that triggered this timeout
     setTimeout(() => client.destroy())
   })

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -64,18 +64,24 @@ test('client calls a https server twice', (t) => {
 })
 
 test('client calculates correct duration when using pipelining', (t) => {
-  t.plan(4)
+  t.plan(6)
 
   const delayResponse = 500
   const lazyServer = helper.startServer({ delayResponse })
   const opts = lazyServer.address()
   opts.pipelining = 2
+  const startTime = process.hrtime()
   const client = new Client(opts)
   let count = 0
 
   client.on('response', (statusCode, length, duration) => {
     t.equal(statusCode, 200, 'status code matches')
+
     t.ok(duration > delayResponse, `Expected response delay > ${delayResponse}ms but got ${duration}ms`)
+
+    const hrduration = process.hrtime(startTime)
+    const maxExpectedDuration = hrduration[0] * 1e3 + hrduration[1] / 1e6
+    t.ok(duration < maxExpectedDuration, `Expected response delay < ${maxExpectedDuration}ms but got ${duration}ms`)
 
     if (++count === 2) {
       client.destroy()
@@ -560,14 +566,14 @@ test('client should throw when attempting to modify the request with a pipelinin
   client.destroy()
 })
 
-test('client resData length should equal pipelining when greater than 1', (t) => {
+test('client pipelined requests cound should equal pipelining when greater than 1', (t) => {
   t.plan(1)
 
   const opts = server.address()
   opts.pipelining = 10
   const client = new Client(opts)
 
-  t.equal(client.resData.length, client.opts.pipelining)
+  t.equal(client.pipelinedRequests.size(), client.opts.pipelining)
 
   client.destroy()
 })

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -66,7 +66,8 @@ test('client calls a https server twice', (t) => {
 test('client calculates correct duration when using pipelining', (t) => {
   t.plan(4)
 
-  const lazyServer = helper.startServer({ delayResponse: 500 })
+  const delayResponse = 500
+  const lazyServer = helper.startServer({ delayResponse })
   const opts = lazyServer.address()
   opts.pipelining = 2
   const client = new Client(opts)
@@ -74,7 +75,7 @@ test('client calculates correct duration when using pipelining', (t) => {
 
   client.on('response', (statusCode, length, duration) => {
     t.equal(statusCode, 200, 'status code matches')
-    t.ok(duration > 500 && duration < 800)
+    t.ok(duration > delayResponse, `Expected response delay > ${delayResponse}ms but got ${duration}ms`)
 
     if (++count === 2) {
       client.destroy()

--- a/test/pipelinedRequestsQueue.test.js
+++ b/test/pipelinedRequestsQueue.test.js
@@ -9,15 +9,16 @@ test('PipelinedRequestsQueue measures time precisely', (t) => {
   const delay = 42
   const queue = new PipelinedRequestsQueue()
 
-  const start = Date.now()
+  const startTime = process.hrtime()
   queue.insertRequest()
   setTimeout(() => {
     const data = queue.terminateRequest()
-    // Measure the duration with the imprecise Date.now()  as opposed to hrtime
-    // An extra millisecond is added just in case there is soem rounding error between hrtime and Date.now()
-    const measuredDuration = Date.now() - start + 1
+
     t.ok(data.duration > delay, `Calculated duration ${data.duration} should not be less than the induced delay ${delay}`)
-    t.ok(data.duration <= measuredDuration, `Calculated duration ${data.duration} should be less than the measured time ${measuredDuration}`)
+
+    const hrduration = process.hrtime(startTime)
+    const maxExpectedDuration = Math.ceil(hrduration[0] * 1e3 + hrduration[1] / 1e6)
+    t.ok(data.duration <= maxExpectedDuration, `Calculated duration ${data.duration} should be less than the max expected duration ${maxExpectedDuration}`)
   }, delay)
 })
 

--- a/test/pipelinedRequestsQueue.test.js
+++ b/test/pipelinedRequestsQueue.test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const test = require('tap').test
+const PipelinedRequestsQueue = require('../lib/pipelinedRequestsQueue')
+
+test('PipelinedRequestsQueue measures time precisely', (t) => {
+  t.plan(2)
+
+  const delay = 42
+  const queue = new PipelinedRequestsQueue()
+
+  const start = Date.now()
+  queue.insertRequest()
+  setTimeout(() => {
+    const data = queue.terminateRequest()
+    // Measure the duration with the imprecise Date.now()  as opposed to hrtime
+    // An extra millisecond is added just in case there is soem rounding error between hrtime and Date.now()
+    const measuredDuration = Date.now() - start + 1
+    t.ok(data.duration > delay, `Calculated duration ${data.duration} should not be less than the induced delay ${delay}`)
+    console.log(delay, data.duration, measuredDuration)
+    t.ok(data.duration <= measuredDuration, `Calculated duration ${data.duration} should be less than the measured time ${measuredDuration}`)
+  }, delay)
+})
+
+test('PipelinedRequestsQueue is a queue/FIFO', (t) => {
+  const COUNT = 3
+  t.plan(COUNT)
+
+  const queue = new PipelinedRequestsQueue()
+
+  let count = COUNT
+  while (count > 0) {
+    queue.insertRequest(count--)
+  }
+
+  count = COUNT
+  while (count > 0) {
+    t.equal(queue.terminateRequest().req, count--)
+  }
+})
+
+test('PipelinedRequestsQueue.clear() empties the queue', (t) => {
+  t.plan(5)
+
+  const queue = new PipelinedRequestsQueue()
+  t.equal(queue.size(), 0)
+  t.equal(queue.toArray().length, 0)
+  queue.insertRequest()
+  queue.insertRequest()
+  queue.insertRequest()
+  t.equal(queue.size(), 3)
+  t.equal(queue.toArray().length, 3)
+  queue.clear()
+  t.equal(queue.terminateRequest(), undefined)
+})
+
+test('PipelinedRequestsQueue methods set values to the request in first-in-last-out order', (t) => {
+  t.plan(6)
+
+  const queue = new PipelinedRequestsQueue()
+  queue.insertRequest(1)
+  queue.insertRequest(2)
+
+  queue.addBody('1')
+  queue.addByteCount(1)
+  queue.setHeaders({ val: '1' })
+
+  const req1 = queue.terminateRequest()
+  t.equal(req1.req, 1)
+  t.equal(req1.body, '1')
+  t.deepEqual(req1.headers, { val: '1' })
+
+  queue.addBody('2')
+  queue.addByteCount(2)
+  queue.setHeaders({ val: '2' })
+
+  const req2 = queue.terminateRequest()
+  t.equal(req2.req, 2)
+  t.equal(req2.body, '2')
+  t.deepEqual(req2.headers, { val: '2' })
+})

--- a/test/pipelinedRequestsQueue.test.js
+++ b/test/pipelinedRequestsQueue.test.js
@@ -17,7 +17,6 @@ test('PipelinedRequestsQueue measures time precisely', (t) => {
     // An extra millisecond is added just in case there is soem rounding error between hrtime and Date.now()
     const measuredDuration = Date.now() - start + 1
     t.ok(data.duration > delay, `Calculated duration ${data.duration} should not be less than the induced delay ${delay}`)
-    console.log(delay, data.duration, measuredDuration)
     t.ok(data.duration <= measuredDuration, `Calculated duration ${data.duration} should be less than the measured time ${measuredDuration}`)
   }, delay)
 })


### PR DESCRIPTION
This PR mostly brings 2 changes:

1. It extracts the previous [cer/rpi](https://github.com/mcollina/autocannon/pull/317/files#r543678831) logic into a specialized queue`PipelinedRequestsQueue`.
2. It adds asserts and tests to ensure the reported response time is bound between the induced delay and the observed response time, from the test's perspective