### PR TITLE
Feat: Add a warmup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Available options:
         A path to a Unix Domain Socket or a Windows Named Pipe. A URL is still required in order to send the correct Host header and path.
   -w/--workers
         Number of worker threads to use to fire requests.
+  -W/--warmup
+       Use a warm up interval before starting sampling.
+       This enables startup processes to finish and traffic to normalize before sampling begins
+       use -c and -d sub args e.g. `--warmpup [ -c 1 -d 3 ]`
   --on-port
         Start the command listed after -- on the command line. When it starts listening on a port,
         start sending requests to that port. A URL is still required in order to send requests to

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Available options:
   -E/--expectBody EXPECTED
         Ensure the body matches this value. If enabled, mismatches count towards bailout.
         Enabling this option will slow down the load testing.
+  --renderStatusCodes
+        Print status codes and their respective statistics.
+  --debug
+        Print connection errors to stderr.        
   -v/--version
         Print the version number.
   -h/--help

--- a/autocannon.js
+++ b/autocannon.js
@@ -103,6 +103,7 @@ function parseArguments (argvs) {
   if (argv.n) {
     argv.renderProgressBar = false
     argv.renderResultsTable = false
+    argv.renderStatusCodes = false
   }
 
   if (argv.version) {

--- a/autocannon.js
+++ b/autocannon.js
@@ -3,7 +3,6 @@
 'use strict'
 
 const crossArgv = require('cross-argv')
-const minimist = require('minimist')
 const fs = require('fs')
 const os = require('os')
 const net = require('net')
@@ -12,10 +11,12 @@ const URL = require('url').URL
 const spawn = require('child_process').spawn
 const managePath = require('manage-path')
 const hasAsyncHooks = require('has-async-hooks')
+const subarg = require('subarg')
 const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
 const printResult = require('./lib/printResult')
 const initJob = require('./lib/init')
 const track = require('./lib/progressTracker')
+const generateSubArgAliases = require('./lib/subargAliases')
 const { checkURL, ofURL } = require('./lib/url')
 const { parseHAR } = require('./lib/parseHAR')
 
@@ -30,63 +31,68 @@ module.exports.track = track
 module.exports.start = start
 module.exports.printResult = printResult
 module.exports.parseArguments = parseArguments
+console.log('ddddddddddddddddd')
+const alias = {
+  connections: 'c',
+  pipelining: 'p',
+  timeout: 't',
+  duration: 'd',
+  amount: 'a',
+  json: 'j',
+  renderLatencyTable: ['l', 'latency'],
+  onPort: 'on-port',
+  method: 'm',
+  headers: ['H', 'header'],
+  body: 'b',
+  form: 'F',
+  servername: 's',
+  bailout: 'B',
+  input: 'i',
+  maxConnectionRequests: 'M',
+  maxOverallRequests: 'O',
+  connectionRate: 'r',
+  overallRate: 'R',
+  ignoreCoordinatedOmission: 'C',
+  reconnectRate: 'D',
+  renderProgressBar: 'progress',
+  title: 'T',
+  version: 'v',
+  forever: 'f',
+  idReplacement: 'I',
+  socketPath: 'S',
+  excludeErrorStats: 'x',
+  expectBody: 'E',
+  workers: 'w',
+  warmup: 'W',
+  help: 'h'
+}
+
+const defaults = {
+  connections: 10,
+  timeout: 10,
+  pipelining: 1,
+  duration: 10,
+  reconnectRate: 0,
+  renderLatencyTable: false,
+  renderProgressBar: true,
+  json: false,
+  forever: false,
+  method: 'GET',
+  idReplacement: false,
+  excludeErrorStats: false,
+  debug: false,
+  workers: 0
+}
 
 function parseArguments (argvs) {
-  const argv = minimist(argvs, {
-    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'renderStatusCodes', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'ignoreCoordinatedOmission'],
-    alias: {
-      connections: 'c',
-      pipelining: 'p',
-      timeout: 't',
-      duration: 'd',
-      amount: 'a',
-      json: 'j',
-      renderLatencyTable: ['l', 'latency'],
-      onPort: 'on-port',
-      method: 'm',
-      headers: ['H', 'header'],
-      body: 'b',
-      form: 'F',
-      servername: 's',
-      bailout: 'B',
-      input: 'i',
-      maxConnectionRequests: 'M',
-      maxOverallRequests: 'O',
-      connectionRate: 'r',
-      overallRate: 'R',
-      ignoreCoordinatedOmission: 'C',
-      reconnectRate: 'D',
-      renderProgressBar: 'progress',
-      renderStatusCodes: 'statusCodes',
-      title: 'T',
-      version: 'v',
-      forever: 'f',
-      idReplacement: 'I',
-      socketPath: 'S',
-      excludeErrorStats: 'x',
-      expectBody: 'E',
-      workers: 'w',
-      help: 'h'
-    },
-    default: {
-      connections: 10,
-      timeout: 10,
-      pipelining: 1,
-      duration: 10,
-      reconnectRate: 0,
-      renderLatencyTable: false,
-      renderProgressBar: true,
-      renderStatusCodes: false,
-      json: false,
-      forever: false,
-      method: 'GET',
-      idReplacement: false,
-      excludeErrorStats: false,
-      debug: false,
-      workers: 0
-    },
+  let argv = subarg(argvs, {
+    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'ignoreCoordinatedOmission'],
+    alias,
+    default: defaults,
     '--': true
   })
+  // subarg does not convert aliases in sub arguments
+  argv = generateSubArgAliases(argv)
 
   argv.url = argv._.length > 1 ? argv._ : argv._[0]
 
@@ -98,7 +104,6 @@ function parseArguments (argvs) {
   if (argv.n) {
     argv.renderProgressBar = false
     argv.renderResultsTable = false
-    argv.renderStatusCodes = false
   }
 
   if (argv.version) {
@@ -183,7 +188,7 @@ function parseArguments (argvs) {
   }
 
   // This is to distinguish down the line whether it is
-  // run via command-line or programatically
+  // run via command-line or programmatically
   argv[Symbol.for('internal')] = true
 
   return argv

--- a/autocannon.js
+++ b/autocannon.js
@@ -54,6 +54,7 @@ const alias = {
   ignoreCoordinatedOmission: 'C',
   reconnectRate: 'D',
   renderProgressBar: 'progress',
+  renderStatusCodes: 'statusCodes',
   title: 'T',
   version: 'v',
   forever: 'f',
@@ -74,6 +75,7 @@ const defaults = {
   reconnectRate: 0,
   renderLatencyTable: false,
   renderProgressBar: true,
+  renderStatusCodes: false,
   json: false,
   forever: false,
   method: 'GET',
@@ -85,7 +87,7 @@ const defaults = {
 
 function parseArguments (argvs) {
   let argv = subarg(argvs, {
-    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'ignoreCoordinatedOmission'],
+    boolean: ['json', 'n', 'help', 'renderLatencyTable', 'renderProgressBar', 'renderStatusCodes', 'forever', 'idReplacement', 'excludeErrorStats', 'onPort', 'debug', 'ignoreCoordinatedOmission'],
     alias,
     default: defaults,
     '--': true

--- a/autocannon.js
+++ b/autocannon.js
@@ -31,7 +31,6 @@ module.exports.track = track
 module.exports.start = start
 module.exports.printResult = printResult
 module.exports.parseArguments = parseArguments
-console.log('ddddddddddddddddd')
 const alias = {
   connections: 'c',
   pipelining: 'p',

--- a/help.txt
+++ b/help.txt
@@ -17,6 +17,10 @@ Available options:
         A path to a Unix Domain Socket or a Windows Named Pipe. A URL is still required in order to send the correct Host header and path.
   -w/--workers
         Number of worker threads to use to fire requests.
+  -W/--warmup
+       Use a warm up interval before starting sampling.
+       This enables startup processes to finish and traffic to normalize before sampling begins
+       use -c and -d sub args e.g. `--warmpup [ -c 1 -d 3 ]`
   --on-port
         Start the command listed after -- on the command line. When it starts listening on a port,
         start sending requests to that port. A URL is still required in order to send requests to

--- a/help.txt
+++ b/help.txt
@@ -20,7 +20,7 @@ Available options:
   -W/--warmup
        Use a warm up interval before starting sampling.
        This enables startup processes to finish and traffic to normalize before sampling begins
-       use -c and -d sub args e.g. `--warmpup [ -c 1 -d 3 ]`
+       use -c and -d sub args e.g. `--warmup [ -c 1 -d 3 ]`
   --on-port
         Start the command listed after -- on the command line. When it starts listening on a port,
         start sending requests to that port. A URL is still required in order to send requests to

--- a/lib/init.js
+++ b/lib/init.js
@@ -10,7 +10,54 @@ const runTracker = require('./runTracker')
 const track = require('./progressTracker')
 
 function init (opts, cb) {
-  return _init(opts, null, cb)
+  const cbPassedIn = (typeof cb === 'function')
+  if (!cbPassedIn && !opts.forever) {
+    if (opts.warmup) {
+      return runWithWarmup(opts)
+    } else {
+      return run(opts)
+    }
+  } else {
+    return _init(opts, null, cb)
+  }
+}
+
+function run (opts) {
+  const tracker = new EE()
+  const promise = new Promise((resolve, reject) => {
+    _init(opts, tracker, (err, results) => {
+      if (err) return reject(err)
+      resolve(results)
+    })
+  })
+  tracker.then = promise.then.bind(promise)
+  tracker.catch = promise.catch.bind(promise)
+
+  return tracker
+}
+
+function runWithWarmup (opts) {
+  const warmupOpts = {
+    ...opts,
+    ...opts.warmup,
+    warmupRunning: true,
+    renderResultsTable: false
+  }
+  const mainTracker = new EE()
+  const warmUpTracker = new EE()
+  const promise = new Promise((resolve, reject) => {
+    _init(warmupOpts, warmUpTracker, (err, warmupResults) => {
+      if (err) return reject(err)
+      _init(opts, mainTracker, (err, results) => {
+        if (err) return reject(err)
+        results.warmup = warmupResults
+        resolve(results)
+      })
+    })
+  })
+  mainTracker.then = promise.then.bind(promise)
+  mainTracker.catch = promise.catch.bind(promise)
+  return mainTracker
 }
 
 function _init (opts, tracker, cb) {
@@ -18,18 +65,6 @@ function _init (opts, tracker, cb) {
   cb = cb || noop
 
   tracker = tracker || new EE()
-
-  if (!cbPassedIn && !opts.forever) {
-    const promise = new Promise((resolve, reject) => {
-      _init(opts, tracker, (err, results) => {
-        if (err) return reject(err)
-        resolve(results)
-      })
-    })
-    tracker.then = promise.then.bind(promise)
-    tracker.catch = promise.catch.bind(promise)
-    return tracker
-  }
 
   opts = validateOpts(opts, cbPassedIn)
 

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -8,7 +8,7 @@
 const ProgressBar = require('progress')
 const Chalk = require('chalk')
 const testColorSupport = require('color-support')
-const ora = require('ora')
+const charSpinner = require('char-spinner')
 const printResult = require('./printResult')
 const { isMainThread } = require('./worker_threads')
 const defaults = {
@@ -81,13 +81,12 @@ function track (instance, opts) {
   })
 
   function showSpinner () {
-    spinner = ora('running...')
-    spinner.start()
+    spinner = charSpinner()
   }
 
   function hideSpinner () {
     if (spinner) {
-      spinner.stop()
+      clearInterval(spinner)
       spinner = null
     }
   }

--- a/lib/progressTracker.js
+++ b/lib/progressTracker.js
@@ -8,7 +8,7 @@
 const ProgressBar = require('progress')
 const Chalk = require('chalk')
 const testColorSupport = require('color-support')
-const charSpinner = require('char-spinner')
+const ora = require('ora')
 const printResult = require('./printResult')
 const { isMainThread } = require('./worker_threads')
 const defaults = {
@@ -28,7 +28,8 @@ function track (instance, opts) {
 
   const chalk = new Chalk.Instance(testColorSupport({ stream: opts.outputStream, alwaysReturn: true }))
   // this default needs to be set after chalk is setup, because chalk is now local to this func
-  opts.progressBarString = opts.progressBarString || `${chalk.green('running')} [:bar] :percent`
+  const runningDescription = opts.warmupRunning ? 'warmup' : 'running'
+  opts.progressBarString = opts.progressBarString || `${chalk.green(runningDescription)} [:bar] :percent`
 
   const iOpts = instance.opts
   let durationProgressBar
@@ -49,9 +50,10 @@ function track (instance, opts) {
         msg += `\n${iOpts.workers} workers`
       }
 
+      const runningType = opts.warmupRunning ? 'warmup' : 'test'
       const message = iOpts.amount
-        ? `Running ${iOpts.amount} requests test @ ${iOpts.url}${socketPath}\n${msg}\n`
-        : `Running ${iOpts.duration}s test @ ${iOpts.url}${socketPath}\n${msg}\n`
+        ? `Running ${iOpts.amount} requests ${runningType} @ ${iOpts.url}${socketPath}\n${msg}\n`
+        : `Running ${iOpts.duration}s ${runningType} @ ${iOpts.url}${socketPath}\n${msg}\n`
 
       logToStream(message)
 
@@ -79,12 +81,13 @@ function track (instance, opts) {
   })
 
   function showSpinner () {
-    spinner = charSpinner()
+    spinner = ora('running...')
+    spinner.start()
   }
 
   function hideSpinner () {
     if (spinner) {
-      clearInterval(spinner)
+      spinner.stop()
       spinner = null
     }
   }

--- a/lib/subargAliases.js
+++ b/lib/subargAliases.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const clone = require('clone')
+
+const subArgAlias = {
+  warmup: {
+    c: 'connections',
+    d: 'duration'
+  }
+}
+
+// Expects args to have already been processed by subarg
+function generateSubargAliases (args) {
+  const aliasedArgs = clone(args)
+
+  function isParentAliasInArgs (argKey) {
+    return aliasedArgs[argKey]
+  }
+
+  function isSubargAnAlias (parentAlias, subArg) {
+    return parentAlias[subArg]
+  }
+
+  function mapAliasForSubarg (parentAlias, parentKey) {
+    const parentArgs = aliasedArgs[parentKey]
+    for (const subArg in parentArgs) {
+      if (isSubargAnAlias(parentAlias, subArg)) {
+        parentArgs[parentAlias[subArg]] = parentArgs[subArg]
+      }
+    }
+  }
+
+  for (const parentKey in subArgAlias) {
+    const parentAlias = subArgAlias[parentKey]
+    if (isParentAliasInArgs(parentKey)) {
+      mapAliasForSubarg(parentAlias, parentKey)
+    }
+  }
+
+  return aliasedArgs
+}
+
+module.exports = generateSubargAliases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autocannon",
-  "version": "7.0.5",
+  "version": "7.0.4",
   "description": "Fast HTTP benchmarking tool written in Node.js",
   "main": "autocannon.js",
   "bin": {
@@ -38,18 +38,16 @@
   },
   "homepage": "https://github.com/mcollina/autocannon#readme",
   "devDependencies": {
-    "bl": "^5.0.0",
+    "bl": "^4.0.3",
     "busboy": "^0.3.1",
     "pre-commit": "^1.1.2",
     "proxyquire": "^2.1.3",
-    "sinon": "^9.2.4",
     "split2": "^3.2.2",
     "standard": "^16.0.3",
     "tap": "^14.10.8"
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "char-spinner": "^1.0.1",
     "cli-table3": "^0.6.0",
     "clone": "^2.1.2",
     "color-support": "^1.1.1",
@@ -63,11 +61,13 @@
     "manage-path": "^2.0.0",
     "minimist": "^1.2.0",
     "on-net-listen": "^1.1.1",
+    "ora": "^5.1.0",
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",
     "reinterval": "^1.1.0",
     "retimer": "^3.0.0",
     "semver": "^7.3.2",
+    "subarg": "^1.0.0",
     "timestring": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autocannon",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "Fast HTTP benchmarking tool written in Node.js",
   "main": "autocannon.js",
   "bin": {
@@ -38,16 +38,18 @@
   },
   "homepage": "https://github.com/mcollina/autocannon#readme",
   "devDependencies": {
-    "bl": "^4.0.3",
+    "bl": "^5.0.0",
     "busboy": "^0.3.1",
     "pre-commit": "^1.1.2",
     "proxyquire": "^2.1.3",
+    "sinon": "^9.2.4",
     "split2": "^3.2.2",
     "standard": "^16.0.3",
     "tap": "^14.10.8"
   },
   "dependencies": {
     "chalk": "^4.1.0",
+    "char-spinner": "^1.0.1",
     "cli-table3": "^0.6.0",
     "clone": "^2.1.2",
     "color-support": "^1.1.1",
@@ -61,7 +63,6 @@
     "manage-path": "^2.0.0",
     "minimist": "^1.2.0",
     "on-net-listen": "^1.1.1",
-    "ora": "^5.1.0",
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",
     "reinterval": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "http-parser-js": "^0.5.2",
     "hyperid": "^2.0.3",
     "manage-path": "^2.0.0",
-    "minimist": "^1.2.0",
     "on-net-listen": "^1.1.1",
     "pretty-bytes": "^5.4.1",
     "progress": "^2.0.3",

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -882,7 +882,6 @@ test('should run when no callback is passed in', (t) => {
     duration: 1
   })
   t.resolveMatch(tracker, { connections: 1 }, 'The main tracker should resolve')
-  t.end()
 })
 
 test('Should run a warmup if one is passed in', (t) => {
@@ -898,7 +897,6 @@ test('Should run a warmup if one is passed in', (t) => {
     }
   })
   t.resolves(tracker, 'The main tracker should resolve')
-  t.end()
 })
 
 test('The warmup should not pollute the main result set', (t) => {
@@ -917,6 +915,5 @@ test('The warmup should not pollute the main result set', (t) => {
     t.equal(result.connections, 3, 'connections should equal the main connections and not the warmup connections')
     t.ok(result.duration >= 1, 'duration should equal the main duration and not the warmup duration')
     t.type(result.warmup, 'object')
-    t.end()
   })
 })

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -872,3 +872,51 @@ test('should throw on invalid HAR', (t) => {
     t.end()
   })
 })
+
+test('should run when no callback is passed in', (t) => {
+  t.plan(1)
+
+  const tracker = initJob({
+    url: 'http://localhost:' + server.address().port,
+    connections: 1,
+    duration: 1
+  })
+  t.resolveMatch(tracker, { connections: 1 }, 'The main tracker should resolve')
+  t.end()
+})
+
+test('Should run a warmup if one is passed in', (t) => {
+  t.plan(1)
+
+  const tracker = initJob({
+    url: 'http://localhost:' + server.address().port,
+    connections: 1,
+    duration: 1,
+    warmup: {
+      connections: 1,
+      duration: 1
+    }
+  })
+  t.resolves(tracker, 'The main tracker should resolve')
+  t.end()
+})
+
+test('The warmup should not pollute the main result set', (t) => {
+  t.plan(3)
+
+  const tracker = initJob({
+    url: 'http://localhost:' + server.address().port,
+    connections: 3,
+    duration: 1,
+    warmup: {
+      connections: 4,
+      duration: 2
+    }
+  })
+  tracker.then((result) => {
+    t.equal(result.connections, 3, 'connections should equal the main connections and not the warmup connections')
+    t.ok(result.duration >= 1, 'duration should equal the main duration and not the warmup duration')
+    t.type(result.warmup, 'object')
+    t.end()
+  })
+})

--- a/test/subargAliases.test.js
+++ b/test/subargAliases.test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const test = require('tap').test
+const generateSubArgAliases = require('../lib/subargAliases')
+
+test('generateSubArgAliases Should generate warmup aliases', (t) => {
+  t.plan(4)
+
+  const args = {
+    connections: 1,
+    duration: 2,
+    warmup: {
+      c: 3,
+      d: 4
+    }
+  }
+
+  const result = generateSubArgAliases(args)
+
+  t.equal(result.connections, 1)
+  t.equal(result.duration, 2)
+  t.equal(result.warmup.connections, 3)
+  t.equal(result.warmup.duration, 4)
+  t.end()
+})
+
+test('generateSubArgAliases should not process aliases that are not defined in subargAliases.js', (t) => {
+  t.plan(5)
+
+  const args = {
+    connections: 1,
+    warmup: {
+      c: 3,
+      T: 'A title'
+    }
+  }
+
+  const result = generateSubArgAliases(args)
+
+  t.equal(result.connections, 1)
+  t.equal(result.warmup.connections, 3)
+  t.equal(result.warmup.c, 3)
+  t.equal(result.warmup.T, 'A title')
+  t.equal(Object.keys(result.warmup).length, 3)
+  t.end()
+})

--- a/test/subargAliases.test.js
+++ b/test/subargAliases.test.js
@@ -21,7 +21,6 @@ test('generateSubArgAliases Should generate warmup aliases', (t) => {
   t.equal(result.duration, 2)
   t.equal(result.warmup.connections, 3)
   t.equal(result.warmup.duration, 4)
-  t.end()
 })
 
 test('generateSubArgAliases should not process aliases that are not defined in subargAliases.js', (t) => {
@@ -42,5 +41,4 @@ test('generateSubArgAliases should not process aliases that are not defined in s
   t.equal(result.warmup.c, 3)
   t.equal(result.warmup.T, 'A title')
   t.equal(Object.keys(result.warmup).length, 3)
-  t.end()
 })


### PR DESCRIPTION
### Adds a warmup option so that the server being tested can get up to speed before the stats start to be generated

Closes: https://github.com/mcollina/autocannon/issues/202

### To test:
To test add a warmup flag to the command line or in the config: Eg
```
node autocannon -c 3 -d -W [ -c 2 -d 2 ] http://localhost:5000
```
or
```
node autocannon -c 3 -d --warmup [ --connections 2 --duration 2 ] http://localhost:5000
```
- Check that it works in both command line and imported modes
- Check that additional flags are being correctly utilised and aliased 
- Check that the display on the command line whilst running is displaying the warmup
- Check that the final reported stats do not include the warmup period
- Due to refactoring in `lib/init` check that all calls to `init` work as expected.

### Notes
- Replaces `minimist` with `subarg` so that we can include subarguments such as `--warmup`. `subarg` uses `minimist` internally so the change is minimal - however `subarg` does not use nested aliases and so a new function (`lib/subargAliases`) has been created to enable this
- `lib/init` Has had some refactoring. This was due to the original implementation relying on recursive calling of `_init` which already took considerable cognitive load to trace through the possible paths. Adding a warmup path to the recursion would only have made this situation worse and more bug prone. Instead I have removed the recursive call to `_init` and created two new helper functions that call `_init` exactly as required. 


https://user-images.githubusercontent.com/4930551/114038133-841eae00-9879-11eb-8d1a-a9d2e30732fb.mov