### PR TITLE
fix: use headers from requests if any

### DIFF
--- a/lib/requestIterator.js
+++ b/lib/requestIterator.js
@@ -88,7 +88,7 @@ RequestIterator.prototype.rebuildRequest = function () {
   let data
   this.resetted = false
   if (this.currentRequest) {
-    this.currentRequest.headers = this.headers
+    this.currentRequest.headers = this.currentRequest.headers || this.headers
     data = this.requestBuilder(this.currentRequest, this.context)
     if (data) {
       this.currentRequest.requestBuffer = this.reqDefaults.idReplacement

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -996,36 +996,3 @@ test('client supports receiving large response body', (t) => {
     client.destroy()
   })
 })
-
-test('client supports receiving large response body', (t) => {
-  t.plan(2)
-
-  const mockBody = Array.from({ length: 1024 * 10 }, (_, i) => `str-${i}`).join('\n')
-  const server = http.createServer((req, res) => {
-    res.end(mockBody)
-  })
-  server.listen(0)
-  server.unref()
-
-  let onResponseCalled = 0
-  const opts = server.address()
-  opts.method = 'POST'
-  opts.body = Buffer.from('hello world')
-  opts.requests = [
-    {
-      path: '/',
-      method: 'GET',
-      onResponse: (...args) => {
-        onResponseCalled++
-      }
-    }
-  ]
-
-  const client = new Client(opts)
-
-  client.on('response', (statusCode, length) => {
-    t.equal(onResponseCalled, 1, 'onResponse should be called only once')
-    t.equal(statusCode, 200, 'status code matches')
-    client.destroy()
-  })
-})

--- a/test/requestIterator.test.js
+++ b/test/requestIterator.test.js
@@ -53,7 +53,7 @@ test('request iterator should use headers from requests', (t) => {
       path: '/',
       method: 'POST',
       headers: {
-        'content-type': 'application/json',
+        'content-type': 'application/json'
       },
       body: JSON.stringify({ foo: 'bar' })
     },
@@ -61,7 +61,7 @@ test('request iterator should use headers from requests', (t) => {
       path: '/2',
       method: 'POST',
       headers: {
-        'content-type': 'text/html',
+        'content-type': 'text/html'
       },
       body: JSON.stringify({ foo: 'bar' })
     }

--- a/test/requestIterator.test.js
+++ b/test/requestIterator.test.js
@@ -44,6 +44,35 @@ test('request iterator should create requests with overwritten defaults', (t) =>
     'request is okay')
 })
 
+test('request iterator should use headers from requests', (t) => {
+  t.plan(2)
+
+  const opts = server.address()
+  opts.requests = [
+    {
+      path: '/',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ foo: 'bar' })
+    },
+    {
+      path: '/2',
+      method: 'POST',
+      headers: {
+        'content-type': 'text/html',
+      },
+      body: JSON.stringify({ foo: 'bar' })
+    }
+  ]
+  const iterator = new RequestIterator(opts)
+
+  t.same(iterator.currentRequest.headers['content-type'], 'application/json')
+  iterator.nextRequest()
+  t.same(iterator.currentRequest.headers['content-type'], 'text/html')
+})
+
 test('request iterator should create requests with overwritten defaults', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
This PR aims to fix a behavior expected in https://github.com/rafaelGSS/autobench#config-file by specifying `headers` inside `opts.requests`.

Currently, the lib isn't using `request[index].headers` in the requests, this PR should solve it.