### PR TITLE
Fixes #432 - Updating to only load the help text when required

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -12,7 +12,6 @@ const spawn = require('child_process').spawn
 const managePath = require('manage-path')
 const hasAsyncHooks = require('has-async-hooks')
 const subarg = require('subarg')
-const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
 const printResult = require('./lib/printResult')
 const initJob = require('./lib/init')
 const track = require('./lib/progressTracker')
@@ -119,6 +118,7 @@ function parseArguments (argvs) {
   }
 
   if (!checkURL(argv.url) || argv.help) {
+    const help = fs.readFileSync(path.join(__dirname, 'help.txt'), 'utf8')
     console.error(help)
     return
   }


### PR DESCRIPTION
Updated to move the call to load the help text inside the `parseArguments` which only gets called when autocannon is invoked via the CLI. For module imports, the default export is the `initJob` function which does not call parseArguments. 

You could still run into this problem if you tried to import the parseArguments function from inside a webpack / otherwise packaged module, e.g.:

    const { parseArguments, start } = require('autocannon');
    const args = // some source of arguments
    start(parseArguments(args)); 

...but honestly I'd see that as an edge case.