### PR TITLE
update: use sample interval default 1000

### DIFF
--- a/autocannon.js
+++ b/autocannon.js
@@ -98,8 +98,6 @@ function parseArguments (argvs) {
 
   argv.url = argv._.length > 1 ? argv._ : argv._[0]
 
-  argv.sampleInt = Math.round(argv.sampleInt * 1000) // convert seconds to milliseconds
-
   if (argv.onPort) {
     argv.spawn = argv['--']
   }

--- a/autocannon.js
+++ b/autocannon.js
@@ -72,7 +72,7 @@ const defaults = {
   timeout: 10,
   pipelining: 1,
   duration: 10,
-  sampleInt: 1,
+  sampleInt: 1000,
   reconnectRate: 0,
   renderLatencyTable: false,
   renderProgressBar: true,

--- a/help.txt
+++ b/help.txt
@@ -13,8 +13,8 @@ Available options:
         The number of seconds to run the autocannon. default: 10.
   -a/--amount NUM
         The number of requests to make before exiting the benchmark. If set, duration is ignored.
-  -L SEC
-        The number of seconds to elapse between taking samples. This controls the sample interval, & therefore the total number of samples, which affects statistical analyses. default: 1.
+  -L NUM
+        The number of milliseconds to elapse between taking samples. This controls the sample interval, & therefore the total number of samples, which affects statistical analyses. default: 1.
   -S/--socketPath
         A path to a Unix Domain Socket or a Windows Named Pipe. A URL is still required to send the correct Host header and path.
   -w/--workers

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -5,7 +5,7 @@ const defaultOptions = {
   method: 'GET',
   duration: 10,
   connections: 10,
-  sampleInt: 1,
+  sampleInt: 1000,
   pipelining: 1,
   timeout: 10,
   maxConnectionRequests: 0,

--- a/test/sampleInt.test.js
+++ b/test/sampleInt.test.js
@@ -48,11 +48,11 @@ test('validate should not return an error', (t) => {
   t.equal(result.sampleInt, 2)
 })
 
-test('parseArguments should return sampleInt in ms (2000)', (t) => {
+test('parseArguments should accept value in ms (2000)', (t) => {
   t.plan(1)
 
   const args = [
-    '-L', 2,
+    '-L', 2000,
     'https://github.com/mcollina/autocannon'
   ]
 
@@ -66,7 +66,7 @@ test('run should return sampleInt == 2000 & samples == 3', (t) => {
 
   initJob({
     duration: 6,
-    sampleInt: 2000, // an input of 2 seconds will be passed in as 2000 because this is after it is parsed in autocannon.js
+    sampleInt: 2000,
     url: 'https://github.com/mcollina/autocannon'
   }, (err, res) => {
     if (err) {


### PR DESCRIPTION
[This PR](https://github.com/mcollina/autocannon/pull/425) is causing unexpected behavior in some measurements:

https://github.com/fastify/benchmarks/issues/233 and I believe for most of the users is better to use default as `1000` at least is more readable than:

```
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min   │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼───────┤
│ Req/Sec   │ 16      │ 32      │ 55      │ 89      │ 54.75   │ 11.09   │ 1     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼───────┤
│ Bytes/Sec │ 2.99 kB │ 5.99 kB │ 10.3 kB │ 16.7 kB │ 10.2 kB │ 2.07 kB │ 187 B │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴───────┘

Req/Bytes counts sampled every 0.001 seconds.
```