### PR TITLE
ci: reduce job permissions to minimum

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,8 @@ on: [ push, pull_request ]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Declares the minimum [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) for CI workflows to run at the job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)