### PR TITLE
fix: Sync --help output with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Available options:
         The title to place in the results for identification.
   -b/--body BODY
         The body of the request.
-	Note: This option needs to be used with the '-H/--headers' option in some frameworks
+        NOTE: This option needs to be used with the '-H/--headers' option in some frameworks
   -F/--form FORM
         Upload a form (multipart/form-data). The form options can be a JSON string like
         '{ "field 1": { "type": "text", "value": "a text value"}, "field 2": { "type": "file", "path": "path to the file" } }'

--- a/help.txt
+++ b/help.txt
@@ -35,6 +35,7 @@ Available options:
         The title to place in the results for identification.
   -b/--body BODY
         The body of the request.
+        NOTE: This option needs to be used with the '-H/--headers' option in some frameworks
   -F/--form FORM
         Upload a form (multipart/form-data). The form options can be a JSON string like
         '{ "field 1": { "type": "text", "value": "a text value"}, "field 2": { "type": "file", "path": "path to the file" } }'
@@ -44,7 +45,7 @@ Available options:
         Passing the filepath to the form can be done by using the corresponding option:
         '{ "field name": { "type": "file", "path": "path to the file", "options": { "filepath": "/some/path/myfilename" } } }'
   -i/--input FILE
-        The body of the request.
+        The body of the request. See '-b/body' for more details.
   -H/--headers K=V
         The request headers.
   --har FILE
@@ -63,15 +64,11 @@ Available options:
         The max number of requests to make per second from all connections.
         connection rate will take precedence if both are set.
         NOTE: if using rate limiting and a very large rate is entered which cannot be met,
-              Autocannon will do as many requests as possible per second. Also, latency data will be corrected to 
-              compensate for the effects of the coordinated omission issue. If you are not familiar with the coordinated omission
-              issue, you should probably read [this article](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html)
-              or watch this [Gil Tene's talk](https://www.youtube.com/watch?v=lJ8ydIuPFeU) on the topic.
+              Autocannon will do as many requests as possible per second. Also, latency data will be corrected to compensate for the effects of the coordinated omission issue. If you are not familiar with the coordinated omission issue, you should probably read [this article](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html) or watch this [Gil Tene's talk](https://www.youtube.com/watch?v=lJ8ydIuPFeU) on the topic.
   -C/--ignoreCoordinatedOmission
         Ignore the coordinated omission issue when requests should be sent at a fixed rate using 'connectionRate' or 'overallRate'.
         NOTE: it is not recommended to enable this option.
-              When the request rate cannot be met because the server is too slow,
-              many request latencies might be missing and Autocannon might report a misleading latency distribution.
+              When the request rate cannot be met because the server is too slow, many request latencies might be missing and Autocannon might report a misleading latency distribution.
   -D/--reconnectRate NUM
         The number of requests to make before resetting a connections connection to the
         server.
@@ -94,6 +91,12 @@ Available options:
         Enabling this option will slow down the load testing.
   --renderStatusCodes
         Print status codes and their respective statistics.
+  --cert
+        Path to cert chain in pem format
+  --key
+        Path to private key for specified cert in pem format
+  --ca
+        Path to trusted ca certificates for the test. This argument accepts both a single file as well as a list of files
   --debug
         Print connection errors to stderr.
   -v/--version


### PR DESCRIPTION
The --help output was outdated to what was in README. Synced the content
from the readme into help.txt and did one minor formatting change.