### PR TITLE
Accept host header case-insensitively

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [14, 16, 18]

--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const methods = require('./httpMethods')
-const { getPropInsensitive } = require('./util')
+const { getPropertyCaseInsensitive } = require('./util')
 
 // this is a build request factory, that curries the build request function
 // and sets the default for it
@@ -45,7 +45,7 @@ function requestBuilder (defaults) {
     const headers = reqData.headers
     const body = reqData.body
 
-    let host = getPropInsensitive(reqData.headers, 'host') || getPropInsensitive(reqData, 'host')
+    let host = getPropertyCaseInsensitive(reqData.headers, 'host') || reqData.host
 
     if (!host) {
       const hostname = reqData.hostname

--- a/lib/httpRequestBuilder.js
+++ b/lib/httpRequestBuilder.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const methods = require('./httpMethods')
+const { getPropInsensitive } = require('./util')
 
 // this is a build request factory, that curries the build request function
 // and sets the default for it
@@ -44,7 +45,8 @@ function requestBuilder (defaults) {
     const headers = reqData.headers
     const body = reqData.body
 
-    let host = reqData.headers.host || reqData.host
+    let host = getPropInsensitive(reqData.headers, 'host') || getPropInsensitive(reqData, 'host')
+
     if (!host) {
       const hostname = reqData.hostname
       const port = reqData.port

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,10 +3,10 @@
 const semver = require('semver')
 const hasWorkerSupport = semver.gte(process.versions.node, '11.7.0')
 
-function getPropInsensitive (obj, key) {
+function getPropertyCaseInsensitive (obj, key) {
   for (const objKey of Object.keys(obj)) {
     if (objKey.toLowerCase() === key.toLowerCase()) return obj[objKey]
   }
 }
 
-module.exports = { hasWorkerSupport, getPropInsensitive }
+module.exports = { hasWorkerSupport, getPropertyCaseInsensitive }

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,4 +3,10 @@
 const semver = require('semver')
 const hasWorkerSupport = semver.gte(process.versions.node, '11.7.0')
 
-module.exports = { hasWorkerSupport }
+function getPropInsensitive (obj, key) {
+  for (const objKey of Object.keys(obj)) {
+    if (objKey.toLowerCase() === key.toLowerCase()) return obj[objKey]
+  }
+}
+
+module.exports = { hasWorkerSupport, getPropInsensitive }

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -344,7 +344,7 @@ test('client supports host custom header with mixed case', (t) => {
   const client = new Client(opts)
 
   server.once('request', (req, res) => {
-    t.equal(req.headers.Host, 'www.autocannon.com', 'host header matches')
+    t.equal(req.headers.host, 'www.autocannon.com', 'host header matches')
   })
 
   client.on('response', (statusCode, length) => {

--- a/test/httpClient.test.js
+++ b/test/httpClient.test.js
@@ -334,6 +334,25 @@ test('client supports host custom header', (t) => {
   })
 })
 
+test('client supports host custom header with mixed case', (t) => {
+  t.plan(2)
+
+  const opts = server.address()
+  opts.headers = {
+    Host: 'www.autocannon.com'
+  }
+  const client = new Client(opts)
+
+  server.once('request', (req, res) => {
+    t.equal(req.headers.Host, 'www.autocannon.com', 'host header matches')
+  })
+
+  client.on('response', (statusCode, length) => {
+    t.equal(statusCode, 200, 'status code matches')
+    client.destroy()
+  })
+})
+
 test('client supports response trailers', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
This makes CLI `-H 'Host: foo'` work where previously it did not identify the header correctly because it was case-sensitive.