### PR TITLE
fix Cannot access 'connection' before initialization

### DIFF
--- a/samples/customise-individual-connection.js
+++ b/samples/customise-individual-connection.js
@@ -7,6 +7,8 @@ const server = http.createServer(handle)
 
 server.listen(0, startBench)
 
+let connection = 0
+
 function handle (req, res) {
   res.end('hello world')
 }
@@ -20,8 +22,6 @@ function startBench () {
     duration: 10,
     setupClient
   }, finishedBench)
-
-  let connection = 0
 
   function setupClient (client) {
     client.setBody('connection number', connection++)


### PR DESCRIPTION
trying with node version v16.14.2 I get this error 

```
node samples/customise-individual-connection.js 
/Users/.../workspace/autocannon/samples/customise-individual-connection.js:27
    client.setBody('connection number', connection++)
           ^

ReferenceError: Cannot access 'connection' before initialization
... 
... 

```