### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/samples/bench-multi-url.js
+++ b/samples/bench-multi-url.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 function createHandler (serverName) {

--- a/samples/customise-individual-connection.js
+++ b/samples/customise-individual-connection.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/customise-verifyBody-workers.js
+++ b/samples/customise-verifyBody-workers.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const http = require('http')
-const path = require('path')
+const http = require('node:http')
+const path = require('node:path')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/customise-verifyBody.js
+++ b/samples/customise-verifyBody.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/init-context.js
+++ b/samples/init-context.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/modifying-request.js
+++ b/samples/modifying-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/request-context-workers.js
+++ b/samples/request-context-workers.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const http = require('http')
-const path = require('path')
+const http = require('node:http')
+const path = require('node:path')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/request-context.js
+++ b/samples/request-context.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/requests-sample.js
+++ b/samples/requests-sample.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/track-run-workers.js
+++ b/samples/track-run-workers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/track-run.js
+++ b/samples/track-run.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)

--- a/samples/using-id-replacement.js
+++ b/samples/using-id-replacement.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const autocannon = require('../autocannon')
 
 const server = http.createServer(handle)


### PR DESCRIPTION
Introduced as part of v16.0.0 and  v14.18.0, this allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).