### PR TITLE
improve string output for Req/Sec

### DIFF
--- a/lib/printResult.js
+++ b/lib/printResult.js
@@ -30,7 +30,7 @@ const printResult = (result, opts) => {
     head: asColor(chalk.cyan, ['Stat', '1%', '2.5%', '50%', '97.5%', 'Avg', 'Stdev', 'Min'])
   })
 
-  requests.push(asHighRow(chalk.bold('Req/Sec'), result.requests))
+  requests.push(asHighRow(chalk.bold('Req/Sec'), asNumber(result.requests)))
   requests.push(asHighRow(chalk.bold('Bytes/Sec'), asBytes(result.throughput)))
   logToLocalStr(requests.toString())
 
@@ -131,6 +131,18 @@ function asMs (stat) {
     result[k] = `${stat[k]} ms`
   }
   result.max = typeof stat.max === 'string' ? stat.max : `${Math.floor(stat.max * 100) / 100} ms`
+
+  return result
+}
+
+function asNumber (stat) {
+  const result = Object.create(null)
+  for (const k of Object.keys(stat)) {
+    result[k] = stat[k].toLocaleString(undefined, {
+      // to show all digits
+      maximumFractionDigits: 20
+    })
+  }
 
   return result
 }


### PR DESCRIPTION
Before:


```
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬────────────┬──────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg        │ Stdev    │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Req/Sec   │ 126719  │ 126719  │ 146815  │ 149759  │ 142995.21  │ 8486.98  │ 126696  │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Bytes/Sec │ 23.8 MB │ 23.8 MB │ 27.6 MB │ 28.1 MB │ 26.9 MB    │ 1.6 MB   │ 23.8 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴────────────┴──────────┴─────────┘
```


After:

```
[1] ┌───────────┬─────────┬─────────┬─────────┬─────────┬────────────┬──────────┬─────────┐
[1] │ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg        │ Stdev    │ Min     │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Req/Sec   │ 126,719 │ 126,719 │ 146,815 │ 149,759 │ 142,995.21 │ 8,486.98 │ 126,696 │
[1] ├───────────┼─────────┼─────────┼─────────┼─────────┼────────────┼──────────┼─────────┤
[1] │ Bytes/Sec │ 23.8 MB │ 23.8 MB │ 27.6 MB │ 28.1 MB │ 26.9 MB    │ 1.6 MB   │ 23.8 MB │
[1] └───────────┴─────────┴─────────┴─────────┴─────────┴────────────┴──────────┴─────────┘
```