### PR TITLE
fix: table would still be rendered in JSON mode when writing to file

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -66,6 +66,10 @@ module.exports = function validateOpts (opts, cbPassedIn) {
   // fill in defaults after
   opts = defaultOpts(opts)
 
+  if (opts.json === true) {
+    opts.renderProgressBar = opts.renderResultsTable = opts.renderLatencyTable = false
+  }
+
   if (opts.requests) {
     if (opts.requests.some(r => !isValidFn(r.setupRequest))) {
       return new Error('Invalid option setupRequest, please provide a function (or file path when in workers mode)')

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -228,3 +228,21 @@ test('validateOpts should return an error when forever is used with workers', { 
   t.ok(result instanceof Error)
   t.equal(result.message, 'Using `forever` option isn\'t currently supported with workers')
 })
+
+test('validateOpts should not set render options by default', (t) => {
+  t.plan(3)
+
+  const result = validateOpts({ url: 'http://localhost' })
+  t.equal(result.renderProgressBar, undefined)
+  t.equal(result.renderResultsTable, undefined)
+  t.equal(result.renderLatencyTable, undefined)
+})
+
+test('validateOpts should disable render options when json is true', (t) => {
+  t.plan(3)
+
+  const result = validateOpts({ url: 'http://localhost', json: true })
+  t.equal(result.renderProgressBar, false)
+  t.equal(result.renderResultsTable, false)
+  t.equal(result.renderLatencyTable, false)
+})


### PR DESCRIPTION
Fixes one of the two bugs described in #474

### Before

`$ node autocannon.js http://google.com/ --json > output.txt 2>&1`

```
Running 10s test @ http://google.com/
10 connections


^[[90m┌─────────^[[39m^[[90m┬──────^[[39m^[[90m┬──────^[[39m^[[90m┬───────^[[39m^[[90m┬──────^[[39m^[[90m┬──────^[[39m^[[90m┬───────^[[39m^[[90m┬──────┐^[[39m
^[[90m│^[[39m^[[31m Stat    ^[[39m^[[90m│^[[39m^[[31m 2.5% ^[[39m^[[90m│^[[39m^[[31m 50%  ^[[39m^[[90m│^[[39m^[[31m 97.5% ^[[39m^[[90m│^[[39m^[[31m 99%  ^[[39m^[[90m│^[[39m^[[31m Avg  ^[[39m^[[90m│^[[39m^[[31m Stdev ^[[39m^[[90m│^[[39m^[[31m Max  ^[[39m^[[90m│^[[39m
^[[90m├─────────^[[39m^[[90m┼──────^[[39m^[[90m┼──────^[[39m^[[90m┼───────^[[39m^[[90m┼──────^[[39m^[[90m┼──────^[[39m^[[90m┼───────^[[39m^[[90m┼──────┤^[[39m
^[[90m│^[[39m Latency ^[[90m│^[[39m 0 ms ^[[90m│^[[39m 0 ms ^[[90m│^[[39m 0 ms  ^[[90m│^[[39m 0 ms ^[[90m│^[[39m 0 ms ^[[90m│^[[39m 0 ms  ^[[90m│^[[39m 0 ms ^[[90m│^[[39m
^[[90m└─────────^[[39m^[[90m┴──────^[[39m^[[90m┴──────^[[39m^[[90m┴───────^[[39m^[[90m┴──────^[[39m^[[90m┴──────^[[39m^[[90m┴───────^[[39m^[[90m┴──────┘^[[39m
^[[90m┌───────────^[[39m^[[90m┬─────^[[39m^[[90m┬──────^[[39m^[[90m┬─────^[[39m^[[90m┬───────^[[39m^[[90m┬─────^[[39m^[[90m┬───────^[[39m^[[90m┬─────┐^[[39m
^[[90m│^[[39m^[[31m Stat      ^[[39m^[[90m│^[[39m^[[31m 1%  ^[[39m^[[90m│^[[39m^[[31m 2.5% ^[[39m^[[90m│^[[39m^[[31m 50% ^[[39m^[[90m│^[[39m^[[31m 97.5% ^[[39m^[[90m│^[[39m^[[31m Avg ^[[39m^[[90m│^[[39m^[[31m Stdev ^[[39m^[[90m│^[[39m^[[31m Min ^[[39m^[[90m│^[[39m
^[[90m├───────────^[[39m^[[90m┼─────^[[39m^[[90m┼──────^[[39m^[[90m┼─────^[[39m^[[90m┼───────^[[39m^[[90m┼─────^[[39m^[[90m┼───────^[[39m^[[90m┼─────┤^[[39m
^[[90m│^[[39m Req/Sec   ^[[90m│^[[39m 0   ^[[90m│^[[39m 0    ^[[90m│^[[39m 0   ^[[90m│^[[39m 0     ^[[90m│^[[39m 0   ^[[90m│^[[39m 0     ^[[90m│^[[39m 0   ^[[90m│^[[39m
^[[90m├───────────^[[39m^[[90m┼─────^[[39m^[[90m┼──────^[[39m^[[90m┼─────^[[39m^[[90m┼───────^[[39m^[[90m┼─────^[[39m^[[90m┼───────^[[39m^[[90m┼─────┤^[[39m
^[[90m│^[[39m Bytes/Sec ^[[90m│^[[39m 0 B ^[[90m│^[[39m 0 B  ^[[90m│^[[39m 0 B ^[[90m│^[[39m 0 B   ^[[90m│^[[39m 0 B ^[[90m│^[[39m 0 B   ^[[90m│^[[39m 0 B ^[[90m│^[[39m
^[[90m└───────────^[[39m^[[90m┴─────^[[39m^[[90m┴──────^[[39m^[[90m┴─────^[[39m^[[90m┴───────^[[39m^[[90m┴─────^[[39m^[[90m┴───────^[[39m^[[90m┴─────┘^[[39m

Req/Bytes counts sampled once per second.
# of samples: 10

20 requests in 10.03s, 0 B read
10 errors (10 timeouts)
{"url":"http://google.com/","connections":10,"sampleInt":1000,"pipelining":1,"workers":0,"duration":10.03,"samples":10,"start":"2024-03-12T03:06:43.621Z","finish":"2024-03-12T03:06:53.651Z","errors":10,"timeouts":10,"mismatches":0,"non2xx":0,"resets":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"statusCodeStats":{},"latency":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0,"totalCount":0},"requests":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"total":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0,"sent":20},"throughput":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"total":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0}}
```

### After

`$ node autocannon.js http://google.com/ --json > output.txt 2>&1`

```
{"url":"http://google.com/","connections":10,"sampleInt":1000,"pipelining":1,"workers":0,"duration":10.03,"samples":10,"start":"2024-03-12T02:47:59.420Z","finish":"2024-03-12T02:48:09.447Z","errors":10,"timeouts":10,"mismatches":0,"non2xx":0,"resets":0,"1xx":0,"2xx":0,"3xx":0,"4xx":0,"5xx":0,"statusCodeStats":{},"latency":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0,"totalCount":0},"requests":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"total":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0,"sent":20},"throughput":{"average":0,"mean":0,"stddev":0,"min":0,"max":0,"total":0,"p0_001":0,"p0_01":0,"p0_1":0,"p1":0,"p2_5":0,"p10":0,"p25":0,"p50":0,"p75":0,"p90":0,"p97_5":0,"p99":0,"p99_9":0,"p99_99":0,"p99_999":0}}
```