### PR TITLE
Update README to make behavior of idReplacement more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Available options:
   -l/--latency
         Print all the latency data. default: false.
   -I/--idReplacement
-        Enable replacement of [<id>] with a randomly generated ID within the request body. default: false.
+        Enable replacement of `[<id>]` with a randomly generated ID within the request body. e.g. `/items/[<id>]`. default: false.
   -j/--json
         Print the output as newline delimited JSON. This will cause the progress bar and results not to be rendered. default: false.
   -f/--forever


### PR DESCRIPTION
As a user of Autocannon, it took far too long to figure out why the idReplacement system was not working. Ultimately it was the source code which revealed that replacement target was, _in its entirety_, `[<id>]`. It's a bit unusual to have a two character wrapper where both characters are different, so we interpreted the square braces as a code container in the same way backticks might be used. It appears in other parts of the README, you've used backticks to better represent that the entire string is the target. So I've updated the command line example with this as well.