### PR TITLE
add fixedLength option to hyperid istance to generate 33 Bytes length id (#539)

### DIFF
--- a/lib/requestIterator.js
+++ b/lib/requestIterator.js
@@ -26,7 +26,7 @@ function RequestIterator (opts) {
     return new RequestIterator(opts)
   }
 
-  this.hyperid = hyperid({ urlSafe: true })
+  this.hyperid = hyperid({ urlSafe: true, fixedLength: true })
   this.resetted = false
   this.headers = {}
   this.initialContext = opts.initialContext || {}


### PR DESCRIPTION
Related to #539

Fixes the correct request length set in Header-Length when the placeholder replacement option `[<id>]` is used.